### PR TITLE
refactor: extract app.py into focused modules

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,239 +1,39 @@
+"""
+실시간 자막 서비스 - Streamlit 메인 UI
+모든 비즈니스 로직은 별도 모듈에 위치:
+- translation.py: 번역 서비스
+- services.py: OpenAI/AWS 세션 관리
+- websocket_handler.py: WebSocket 서버/핸들러
+"""
+
 import asyncio
 import json
 import os
-import socket
 import threading
-import time
-from datetime import datetime, timedelta
 
-import boto3
-import httpx
 import streamlit as st
-import websockets
-from botocore.exceptions import ClientError
 from dotenv import load_dotenv
 
-from auth import check_usage_limit, get_current_user, update_user_session
-
-# 사용자 관리 시스템 imports
-from database import get_usage_log_model, get_user_model
+from auth import (
+    display_login_form,
+    display_user_info,
+    get_current_user,
+    init_session_state,
+    is_authenticated,
+)
+from services import (
+    AWS_ACCESS_KEY_ID,
+    AWS_SECRET_ACCESS_KEY,
+    create_openai_session,
+)
+from websocket_handler import start_websocket_server
 
 # Load environment variables
 load_dotenv()
 
-# Global variable to store WebSocket port
-WEBSOCKET_PORT = None
-
-
-def find_free_port(start_port=8765, max_port=8800):
-    """동적으로 사용 가능한 포트 찾기"""
-    for port in range(start_port, max_port + 1):
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.bind(("localhost", port))
-                print(f"[Port] 포트 {port} 사용 가능")
-                return port
-        except OSError:
-            continue
-
-    # 지정된 범위에서 포트를 찾지 못한 경우, OS에 자동 할당 요청
-    try:
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("localhost", 0))  # 0번 포트로 자동 할당
-            port = s.getsockname()[1]
-            print(f"[Port] OS 자동 할당 포트: {port}")
-            return port
-    except OSError:
-        raise Exception("사용 가능한 포트를 찾을 수 없습니다")
-
-
-def split_into_sentences(text, language="ko"):
-    """텍스트를 문장 단위로 분리"""
-    import re
-
-    if language.startswith("ko"):
-        # 한국어 문장 분리 개선
-        # 1. 명확한 문장 종결 패턴
-        text = re.sub(r"([.!?])([가-힣])", r"\1 \2", text)  # 구두점 뒤 공백 추가
-
-        # 2. 다양한 종결 어미 고려
-        # - 평서문: 다, 습니다, 합니다, 입니다, 네요, 군요, 어요, 아요, 에요
-        # - 의문문: 까, 까요, 나요, 가요, 을까요, ㄹ까요
-        # - 감탄문: 구나, 네, 군
-        pattern = r"(?<=[.!?])|(?<=다)(?=[\s])|(?<=요)(?=[\s.!?])|(?<=까)(?=[\s.!?])|(?<=네)(?=[\s.!?])|(?<=군)(?=[\s.!?])|(?<=나)(?=[\s.!?])"
-        sentences = re.split(pattern, text)
-
-        # 재결합 및 정리
-        result = []
-        current = ""
-        for sent in sentences:
-            current += sent
-            # 문장이 종결되었는지 확인
-            if re.search(r"[.!?]$|[다요까네군나]$", current.strip()):
-                if current.strip():
-                    result.append(current.strip())
-                current = ""
-        # 마지막 미완성 문장
-        if current.strip():
-            result.append(current.strip())
-        return result
-    else:
-        # 영어 등 문장 분리
-        sentences = re.split(r"(?<=[.!?])\s+", text)
-        return [s.strip() for s in sentences if s.strip()]
-
-
-def translate_with_llm(bedrock_client, text, source_lang, target_lang):
-    """Bedrock LLM을 사용한 고품질 컨텍스트 번역"""
-    try:
-        # 컨텍스트에 맞는 번역 프롬프트 구성
-        if target_lang == "ko":
-            # 다양한 언어 → 한국어
-            source_lang_names = {
-                "en": "영어",
-                "ja": "일본어",
-                "zh": "중국어",
-                "es": "스페인어",
-                "fr": "프랑스어",
-                "de": "독일어",
-            }
-            source_lang_name = source_lang_names.get(source_lang, "원본 언어")
-
-            prompt = f"""다음 {source_lang_name} 텍스트를 청중이 듣기 좋은 자연스러운 한국어로 의역해주세요.
-실시간 컨퍼런스/기술발표 자막으로 사용되며, 완전한 직역보다는 의미 전달이 우선입니다.
-
-원문: "{text}"
-
-번역 가이드라인:
-- 💡 의미 중심: 원문의 핵심 의미를 자연스럽게 전달
-- 🎯 청중 친화적: 듣는 사람이 이해하기 쉬운 한국어 표현
-- 🚀 맥락 반영: 기술발표/비즈니스 상황에 맞는 톤앤매너
-- ⚡ 간결성: 실시간 자막에 적합한 깔끔한 문장 (최대 2문장)
-- 🔧 용어 처리: 기술용어는 한국 개발자들이 실제 사용하는 표현
-- 📝 자연스러움: 한국어 어순과 관용표현 우선, 직역 금지
-
-예시 변환:
-- "Let me walk you through" → "함께 살펴보겠습니다"
-- "It's pretty straightforward" → "사실 꽤 간단합니다"
-- "This is game-changing" → "이건 정말 혁신적이에요"
-- "That landed differently for me" → "제게는 다르게 다가왔습니다"
-
-번역 결과만 출력하세요 (설명, 주석, 부연설명 일절 금지):
-
-한국어 번역:"""
-
-        else:
-            # 한국어 → 영어
-            prompt = f"""다음 한국어를 국제 컨퍼런스에서 쓰이는 자연스러운 영어로 의역해주세요.
-글로벌 청중을 위한 실시간 자막으로, 직역보다는 의미가 잘 전달되는 것이 중요합니다.
-
-원문: "{text}"
-
-번역 가이드라인:
-- 🌍 글로벌 표준: 국제 컨퍼런스에서 실제 쓰이는 자연스러운 영어
-- 💼 프로페셔널: 기술발표/비즈니스에 적합한 톤
-- 🎯 명확성: 비영어권 청중도 이해하기 쉬운 표현
-- ⚡ 간결성: 자막에 적합한 깔끔한 문장
-- 🔧 용어 활용: 업계 표준 기술용어 및 표현 사용
-
-예시 변환:
-- "이걸 한번 보시면" → "Let's take a look at this"
-- "꽤 괜찮은 것 같아요" → "This looks pretty promising"
-- "정말 대단한 기술이에요" → "This is truly impressive technology"
-
-번역 결과만 출력하세요 (설명, 주석, 부연설명 일절 금지):
-
-English translation:"""
-
-        # Claude 모델 사용 (Bedrock 표준 포맷 - 2025 업데이트)
-        body = json.dumps(
-            {
-                "anthropic_version": "bedrock-2023-05-31",
-                "max_tokens": 200,
-                "messages": [
-                    {"role": "user", "content": [{"type": "text", "text": prompt}]}
-                ],
-                "temperature": 0.5,
-                "top_p": 0.9,
-            }
-        )
-
-        # 여러 모델 ID 시도 (안정성 우선)
-        model_ids = [
-            "anthropic.claude-3-5-sonnet-20240620-v1:0",  # 안정 버전
-            "anthropic.claude-3-haiku-20240307-v1:0",  # 빠른 처리
-            "anthropic.claude-3-sonnet-20240229-v1:0",  # 백업 버전
-        ]
-
-        for model_id in model_ids:
-            try:
-                response = bedrock_client.invoke_model(
-                    modelId=model_id,
-                    body=body,
-                    contentType="application/json",
-                    accept="application/json",
-                )
-                break  # 성공하면 루프 종료
-            except Exception as model_error:
-                print(f"    ⚠️ {model_id} 모델 실패: {model_error}")
-                if model_id == model_ids[-1]:  # 마지막 모델도 실패하면
-                    raise model_error
-
-        response_body = json.loads(response["body"].read())
-        translated_text = response_body["content"][0]["text"].strip()
-
-        # 결과 정리 (따옴표나 불필요한 문자 제거)
-        translated_text = translated_text.strip("\"'")
-
-        # 설명 텍스트 제거 (정규식으로 번역 결과만 추출)
-        import re
-
-        # "This translation:" 이후 설명 제거
-        translated_text = re.sub(
-            r"This translation:.*$",
-            "",
-            translated_text,
-            flags=re.DOTALL | re.IGNORECASE,
-        )
-
-        # "Here's a natural..." 패턴 제거
-        translated_text = re.sub(
-            r"Here\'s a natural.*?:",
-            "",
-            translated_text,
-            flags=re.DOTALL | re.IGNORECASE,
-        )
-
-        # "This [설명]:" 패턴 제거
-        translated_text = re.sub(
-            r"This.*?:", "", translated_text, flags=re.DOTALL | re.IGNORECASE
-        )
-
-        # 첫 번째 문장만 추출 (줄바꿈 이전)
-        lines = translated_text.split("\n")
-        if lines:
-            translated_text = lines[0].strip()
-
-        # 따옴표로 둘러싸인 경우 제거
-        translated_text = re.sub(r'^["\'](.+)["\']$', r"\1", translated_text)
-
-        # 최종 정리
-        translated_text = translated_text.strip()
-
-        return translated_text
-
-    except Exception as e:
-        print(f"    ❌ LLM 번역 실패: {e}")
-        return None
-
-
-# AWS 설정
-AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
-AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
-AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
-
-# OpenAI 설정
-OPENAI_API_KEY = os.getenv("OPENAI_KEY")
+# WebSocket 포트를 dict로 관리 (스레드 간 공유)
+if "websocket_port_ref" not in st.session_state:
+    st.session_state["websocket_port_ref"] = {"port": None}
 
 # 사이드바 상태 관리
 if "sidebar_state" not in st.session_state:
@@ -247,161 +47,32 @@ st.set_page_config(
 )
 
 # 사용자 인증 체크
-from auth import (
-    display_login_form,
-    display_user_info,
-    init_session_state,
-    is_authenticated,
-)
-
 init_session_state()
 
-# 로그인되지 않은 경우 로그인 폼 표시
 if not is_authenticated():
     display_login_form()
     st.stop()
 
 # ALB/프록시 환경에서 HTTPS 지원을 위한 설정
-import streamlit.web.server.server as server
-
 try:
-    server.ENABLE_XSRF_PROTECTION = True
+    import streamlit.web.server.server as _st_server  # noqa: E402
+
+    _st_server.ENABLE_XSRF_PROTECTION = True
     os.environ.setdefault("STREAMLIT_SERVER_ENABLE_XSRF_PROTECTION", "true")
-except:
+except Exception:
     pass
 
-# 전체 페이지 스크롤 방지 + iframe margin 추가
-st.markdown(
-    """
-<style>
-    /* 🚫 전체 페이지 스크롤 완전 차단 */
-    html, body {
-        position: fixed !important;
-        top: 0 !important;
-        left: 0 !important;
-        width: 100% !important;
-        height: 100vh !important;
-        max-height: 100vh !important;
-        overflow: hidden !important;
-        margin: 0 !important;
-        padding: 0 !important;
-        touch-action: none !important;
-        overscroll-behavior: none !important;
-    }
+# 전체 페이지 스크롤 방지 (외부 HTML 파일)
+try:
+    with open("components/scroll_lock.html", encoding="utf-8") as f:
+        scroll_lock_html = f.read()
+    st.markdown(scroll_lock_html, unsafe_allow_html=True)
+except FileNotFoundError:
+    pass
 
-    /* Streamlit 컨테이너들 스크롤 차단 */
-    .stApp, .main, [data-testid="stAppViewContainer"],
-    [data-testid="stSidebar"], .block-container {
-        position: fixed !important;
-        top: 0 !important;
-        left: 0 !important;
-        width: 100% !important;
-        height: 100vh !important;
-        max-height: 100vh !important;
-        overflow: hidden !important;
-        touch-action: none !important;
-        overscroll-behavior: none !important;
-    }
-
-    /* 추가 스크롤 차단 CSS */
-    * {
-        overflow: hidden !important;
-        touch-action: none !important;
-        overscroll-behavior: none !important;
-    }
-
-    /* iframe 제외하고 모든 요소 스크롤 차단 */
-    *:not(iframe):not(iframe *) {
-        overflow: hidden !important;
-    }
-
-    /* 🎯 iframe을 전체 화면에 정확히 맞춤 */
-    .main iframe {
-        width: 100% !important;
-        border: none !important;
-        margin: 0 !important;
-        padding: 0 !important;
-    }
-
-    /* 모든 컨테이너 패딩/마진 제거 */
-    .main > div > div {
-        padding-top: 0rem !important;
-        padding-bottom: 0rem !important;
-        margin: 0 !important;
-    }
-
-    /* Streamlit 기본 여백 완전 제거 */
-    .block-container {
-        padding-top: 0rem !important;
-        padding-bottom: 0rem !important;
-        max-height: 100vh !important;
-    }
-
-    /* Streamlit 동적 클래스들의 패딩 완전 제거 */
-    .stMainBlockContainer {
-        padding: 0 !important;
-        margin: 0 !important;
-        height: 100vh !important;
-        max-height: 100vh !important;
-    }
-</style>
-
-<script>
-    // JavaScript로 스크롤 완전 차단
-    function preventScroll(e) {
-        e.preventDefault();
-        e.stopPropagation();
-        return false;
-    }
-
-    // 페이지 로드 후 실행
-    window.addEventListener('load', function() {
-        // 모든 스크롤 이벤트 차단
-        document.addEventListener('wheel', preventScroll, { passive: false });
-        document.addEventListener('touchmove', preventScroll, { passive: false });
-        document.addEventListener('scroll', preventScroll, { passive: false });
-
-        // 스크롤 관련 키 차단
-        document.addEventListener('keydown', function(e) {
-            if([32, 33, 34, 35, 36, 37, 38, 39, 40].indexOf(e.keyCode) > -1) {
-                e.preventDefault();
-            }
-        }, false);
-
-        // 윈도우 스크롤 강제 방지
-        window.addEventListener('scroll', function() {
-            window.scrollTo(0, 0);
-        });
-
-        // 초기 스크롤 위치 고정
-        window.scrollTo(0, 0);
-        document.body.scrollTop = 0;
-        document.documentElement.scrollTop = 0;
-
-        // 사용량 업데이트 메시지 리스너 추가
-        window.addEventListener('message', function(event) {
-            if (event.data && event.data.type === 'usage_update') {
-                console.log('[Usage Listener] 사용량 업데이트 메시지 수신:', event.data);
-                // 짧은 지연 후 페이지 새로고침으로 사이드바 업데이트
-                setTimeout(function() {
-                    // Query parameter를 통해 새로고침 방지
-                    const url = new URL(window.location);
-                    url.searchParams.set('_t', Date.now());
-                    window.location.href = url.toString();
-                }, 1000);
-            }
-        });
-    });
-</script>
-""",
-    unsafe_allow_html=True,
-)
-
-# 상위 시스템 관리 패널
+# === 사이드바 ===
 with st.sidebar:
     st.header("🧑‍💻 유저 정보")
-
-    # 사용자 정보 표시
     display_user_info()
 
     if not AWS_ACCESS_KEY_ID or not AWS_SECRET_ACCESS_KEY:
@@ -416,14 +87,28 @@ with st.sidebar:
     current_status = st.session_state.get("action", "idle")
 
     with col1:
-        start_disabled = current_status in ["start", "starting"]
+        start_disabled = current_status in [
+            "start",
+            "starting",
+        ]
         start = st.button(
-            "🎯 시작", type="primary", use_container_width=True, disabled=start_disabled
+            "🎯 시작",
+            type="primary",
+            use_container_width=True,
+            disabled=start_disabled,
         )
 
     with col2:
-        stop_disabled = current_status in ["idle", "stop", "error"]
-        stop = st.button("⏹️ 정지", use_container_width=True, disabled=stop_disabled)
+        stop_disabled = current_status in [
+            "idle",
+            "stop",
+            "error",
+        ]
+        stop = st.button(
+            "⏹️ 정지",
+            use_container_width=True,
+            disabled=stop_disabled,
+        )
 
     # 시스템 상태
     st.markdown("---")
@@ -438,10 +123,11 @@ with st.sidebar:
         st.info("🟡 대기 중")
 
     # WebSocket 포트 정보 표시
-    if WEBSOCKET_PORT:
+    ws_port = st.session_state["websocket_port_ref"]["port"]
+    if ws_port:
         st.markdown("---")
         st.subheader("🔗 연결 정보")
-        st.code(f"WebSocket: ws://localhost:{WEBSOCKET_PORT}")
+        st.code(f"WebSocket: ws://localhost:{ws_port}")
         if (
             st.session_state.get("websocket_thread")
             and st.session_state["websocket_thread"].is_alive()
@@ -451,434 +137,11 @@ with st.sidebar:
             st.warning("🟡 WebSocket 서버 대기 중")
 
 
-async def create_openai_session() -> dict:
-    """OpenAI Realtime API ephemeral token 생성"""
-    if not OPENAI_API_KEY:
-        raise ValueError("OpenAI API 키가 설정되지 않았습니다.")
-
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                "https://api.openai.com/v1/realtime/sessions",
-                headers={
-                    "Authorization": f"Bearer {OPENAI_API_KEY}",
-                    "Content-Type": "application/json",
-                    "OpenAI-Beta": "realtime=v1",
-                },
-                json={
-                    "model": "gpt-4o-realtime-preview-2024-12-17",
-                    "voice": "alloy",
-                    "instructions": "You are a helpful assistant that transcribes audio. Focus on accurate transcription of mixed Korean and English speech, technical terms, and code-switching scenarios.",
-                    "input_audio_transcription": {"model": "whisper-1"},
-                    "turn_detection": {
-                        "type": "server_vad",
-                        "threshold": 0.5,
-                        "prefix_padding_ms": 300,
-                        "silence_duration_ms": 500,
-                    },
-                    "modalities": ["audio", "text"],
-                    "temperature": 0.8,
-                },
-            )
-
-            if response.status_code != 200:
-                error_text = response.text
-                print(f"[OpenAI] API 오류: {response.status_code} - {error_text}")
-                raise Exception(f"OpenAI API 오류: {response.status_code}")
-
-            session_data = response.json()
-
-            # 세션 정보 추출 및 만료 시간 계산
-            expires_at = datetime.now() + timedelta(minutes=1)  # 1분 유효
-
-            return {
-                "id": session_data.get("id"),
-                "client_secret": session_data.get("client_secret", {}).get("value"),
-                "expires_at": expires_at.isoformat(),
-                "model": session_data.get(
-                    "model", "gpt-4o-realtime-preview-2024-12-17"
-                ),
-            }
-
-    except httpx.HTTPError as e:
-        print(f"[OpenAI] HTTP 오류: {e}")
-        raise Exception(f"OpenAI 세션 생성 실패: {e}")
-    except Exception as e:
-        print(f"[OpenAI] 예상치 못한 오류: {e}")
-        raise Exception(f"OpenAI 세션 생성 실패: {e}")
-
-
-def create_aws_session() -> dict:
-    """AWS 임시 credentials 생성"""
-    if not AWS_ACCESS_KEY_ID or not AWS_SECRET_ACCESS_KEY:
-        raise ValueError("AWS 자격 증명이 설정되지 않았습니다.")
-
-    try:
-        # STS 클라이언트 생성
-        sts_client = boto3.client(
-            "sts",
-            aws_access_key_id=AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-            region_name=AWS_REGION,
-        )
-
-        # 현재 호출자 ID 확인
-        caller_identity = sts_client.get_caller_identity()
-
-        # 동적으로 할당된 WebSocket 서버 포트 사용
-        websocket_port = WEBSOCKET_PORT or 8765
-
-        print(f"[AWS Session] WebSocket 포트: {websocket_port}")
-
-        return {
-            "access_key_id": AWS_ACCESS_KEY_ID,
-            "secret_access_key": AWS_SECRET_ACCESS_KEY,
-            "region": AWS_REGION,
-            "account_id": caller_identity.get("Account"),
-            "websocket_url": f"ws://localhost:{websocket_port}",
-            "openai_available": bool(OPENAI_API_KEY),  # OpenAI 사용 가능 여부
-        }
-
-    except ClientError as e:
-        error_code = e.response.get("Error", {}).get("Code", "Unknown")
-        if error_code == "InvalidUserID.NotFound":
-            raise ValueError("AWS 자격 증명이 유효하지 않습니다.")
-        elif error_code == "TokenRefreshRequired":
-            raise ValueError("AWS 토큰이 만료되었습니다.")
-        else:
-            raise ValueError(f"AWS 연결 실패: {error_code}")
-    except Exception as e:
-        raise ValueError(f"AWS 세션 생성 실패: {str(e)}") from e
-
-
-# AWS Transcribe 함수 제거됨 - OpenAI Realtime API 사용
-
-
-# 간단한 HTTP 헬스체크 서버
-def start_health_server(port):
-    """ALB 헬스체크용 간단한 HTTP 서버"""
-    import http.server
-    import socketserver
-
-    class HealthHandler(http.server.SimpleHTTPRequestHandler):
-        def do_GET(self):
-            if self.path in ["/", "/health"]:
-                self.send_response(200)
-                self.send_header("Content-type", "text/plain")
-                self.end_headers()
-                self.wfile.write(b"OK")
-            else:
-                self.send_response(404)
-                self.end_headers()
-
-        def log_message(self, format, *args):
-            pass  # 로그 최소화
-
-    try:
-        with socketserver.TCPServer(("0.0.0.0", port), HealthHandler) as httpd:
-            print(f"[Health Check] HTTP 서버 시작: http://0.0.0.0:{port}/health")
-            httpd.serve_forever()
-    except Exception as e:
-        print(f"[Health Check] 서버 오류: {e}")
-
-
-# 새로운 간단한 OpenAI 전용 WebSocket 핸들러
-async def handle_openai_websocket(websocket):
-    """OpenAI Realtime API와 통합된 WebSocket 핸들러"""
-    print(f"[WebSocket] OpenAI 모드 - 클라이언트 연결: {websocket.remote_address}")
-
-    # 첫 메시지로 사용자 정보 수신
-    user_info = None
-    try:
-        first_message = await asyncio.wait_for(websocket.recv(), timeout=5.0)
-        data = json.loads(first_message)
-        if data.get("type") == "auth":
-            user_info = data.get("user")
-            print(
-                f"[Auth] 사용자 인증: {user_info.get('username') if user_info else 'Unknown'}"
-            )
-            await websocket.send(
-                json.dumps({"type": "auth_success", "message": "인증 완료"})
-            )
-    except TimeoutError:
-        print("[Auth] 인증 정보 수신 타임아웃")
-    except Exception as e:
-        print(f"[Auth] 인증 처리 오류: {e}")
-
-    try:
-        # 번역 클라이언트만 초기화
-        translate_client = boto3.client(
-            "translate",
-            aws_access_key_id=AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-            region_name=AWS_REGION,
-        )
-
-        # Bedrock 클라이언트 (선택적)
-        try:
-            bedrock_client = boto3.client(
-                "bedrock-runtime",
-                aws_access_key_id=AWS_ACCESS_KEY_ID,
-                aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
-                region_name=AWS_REGION,
-            )
-            bedrock_available = True
-            print("  🤖 Bedrock LLM 준비 완료")
-        except:
-            bedrock_client = None
-            bedrock_available = False
-            print("  ⚠️ Bedrock 사용 불가, AWS Translate 사용")
-
-        await websocket.send(
-            json.dumps(
-                {
-                    "type": "connection",
-                    "status": "connected",
-                    "message": "OpenAI Realtime + 번역 서비스 준비",
-                }
-            )
-        )
-
-        # 메시지 처리 루프
-        async for message in websocket:
-            try:
-                data = json.loads(message)
-
-                # OpenAI 세션 요청
-                if data["type"] == "request_openai_session":
-                    try:
-                        session = await create_openai_session()
-                        await websocket.send(
-                            json.dumps({"type": "openai_session", "session": session})
-                        )
-                        print("[OpenAI] ✅ 세션 생성 완료")
-                    except Exception as e:
-                        await websocket.send(
-                            json.dumps(
-                                {
-                                    "type": "error",
-                                    "message": f"OpenAI 세션 생성 실패: {str(e)}",
-                                }
-                            )
-                        )
-                        print(f"[OpenAI] ❌ 세션 생성 실패: {e}")
-
-                # OpenAI transcript 수신 및 번역
-                elif data["type"] == "transcript":
-                    transcript = data.get("text", "")
-                    audio_duration = data.get(
-                        "audio_duration_seconds", 0
-                    )  # 실제 음성 길이
-
-                    if not transcript:
-                        continue
-
-                    print(f"[OpenAI] 📝 Transcript: {transcript}")
-                    print(f"[Usage] 🔊 Audio duration: {audio_duration} seconds")
-
-                    # 사용량 체크 (WebSocket으로 전달받은 사용자 정보 사용)
-                    current_user = user_info
-                    if not current_user:
-                        await websocket.send(
-                            json.dumps(
-                                {
-                                    "type": "error",
-                                    "message": "로그인이 필요합니다. 페이지를 새로고침하고 다시 로그인해주세요.",
-                                }
-                            )
-                        )
-                        continue
-
-                    # 사용량 제한 확인 - user_info 파라미터 추가
-                    if not check_usage_limit(audio_duration, current_user):
-                        user_model = get_user_model()
-                        remaining = user_model.get_remaining_seconds(current_user["id"])
-
-                        await websocket.send(
-                            json.dumps(
-                                {
-                                    "type": "usage_exceeded",
-                                    "message": f"사용량이 초과되었습니다. 남은 시간: {remaining}초",
-                                    "remaining_seconds": remaining or 0,
-                                }
-                            )
-                        )
-                        print(
-                            f"[Usage] ❌ 사용량 초과 - User: {current_user['username']}, Remaining: {remaining}초"
-                        )
-                        continue
-
-                    # 간단한 언어 감지
-                    has_korean = any(
-                        ord(c) >= 0xAC00 and ord(c) <= 0xD7A3 for c in transcript
-                    )
-
-                    if has_korean:
-                        source_lang = "ko"
-                        target_lang = "en"
-                    else:
-                        source_lang = "en"
-                        target_lang = "ko"
-
-                    # 번역 처리
-                    translated_text = None
-                    used_llm = False
-
-                    if bedrock_available:
-                        try:
-                            translated_text = translate_with_llm(
-                                bedrock_client, transcript, source_lang, target_lang
-                            )
-                            if translated_text:
-                                used_llm = True
-                                print("[Translate] ✅ LLM 번역 완료")
-                        except:
-                            pass
-
-                    if not translated_text:
-                        try:
-                            response = translate_client.translate_text(
-                                Text=transcript,
-                                SourceLanguageCode=source_lang,
-                                TargetLanguageCode=target_lang,
-                            )
-                            translated_text = response["TranslatedText"]
-                            print("[Translate] ✅ AWS Translate 완료")
-                        except Exception as e:
-                            print(f"[Translate] ❌ 번역 실패: {e}")
-                            translated_text = transcript  # 실패시 원문 그대로
-
-                    # 사용량 기록 (번역 성공 후)
-                    try:
-                        user_model = get_user_model()
-                        usage_log_model = get_usage_log_model()
-
-                        # 실제 음성 길이가 없으면 텍스트 기반 추정 (fallback)
-                        if audio_duration <= 0:
-                            estimated_duration = max(
-                                1, len(transcript) / 5.0
-                            )  # 텍스트 길이 기반 추정
-                            audio_duration = estimated_duration
-                            print(
-                                f"[Usage] 📏 텍스트 기반 추정: {audio_duration:.1f}초"
-                            )
-
-                        # 사용량 추가
-                        user_model.add_usage(current_user["id"], int(audio_duration))
-
-                        # 사용량 로그 기록
-                        usage_log_model.record_usage(
-                            user_id=current_user["id"],
-                            action="transcribe",
-                            duration_seconds=int(audio_duration),
-                            source_language=source_lang,
-                            target_language=target_lang,
-                            metadata={
-                                "transcript_length": len(transcript),
-                                "translated_length": (
-                                    len(translated_text) if translated_text else 0
-                                ),
-                                "used_llm": used_llm,
-                                "estimated": audio_duration
-                                != data.get("audio_duration_seconds", 0),
-                                "source_text": transcript,
-                                "target_text": translated_text,
-                            },
-                        )
-
-                        # 세션의 사용자 정보 업데이트
-                        update_user_session(current_user["id"])
-
-                        print(
-                            f"[Usage] ✅ 사용량 기록 - User: {current_user['username']}, Duration: {audio_duration}초"
-                        )
-
-                    except Exception as e:
-                        print(f"[Usage] ❌ 사용량 기록 실패: {e}")
-
-                    # 사용량 정보 가져오기
-                    user_model = get_user_model()
-                    remaining_seconds = user_model.get_remaining_seconds(
-                        current_user["id"]
-                    )
-
-                    # 결과 전송 (사용량 정보 포함)
-                    await websocket.send(
-                        json.dumps(
-                            {
-                                "type": "transcription_result",
-                                "original_text": transcript,
-                                "translated_text": translated_text,
-                                "source_language": source_lang,
-                                "target_language": target_lang,
-                                "used_llm": used_llm,
-                                "audio_duration": audio_duration,
-                                "timestamp": time.time(),
-                                "remaining_seconds": remaining_seconds,
-                                "user_id": current_user["id"],
-                            }
-                        )
-                    )
-
-            except json.JSONDecodeError:
-                await websocket.send(
-                    json.dumps({"type": "error", "message": "Invalid JSON format"})
-                )
-            except Exception as e:
-                print(f"[WebSocket] 메시지 처리 오류: {e}")
-                await websocket.send(json.dumps({"type": "error", "message": str(e)}))
-
-    except Exception as e:
-        print(f"[WebSocket] 연결 오류: {e}")
-    finally:
-        print("[WebSocket] 클라이언트 연결 종료")
-
-
-def start_websocket_server():
-    """WebSocket 서버 시작 (동적 포트 할당)"""
-    global WEBSOCKET_PORT
-    try:
-        # 동적으로 사용 가능한 포트 찾기
-        free_port = find_free_port()
-        print(f"[WebSocket] 할당된 포트: {free_port}")
-
-        # 글로벌 변수에 포트 저장
-        WEBSOCKET_PORT = free_port
-
-        # ALB 헬스체크는 "/" 경로로 WebSocket 업그레이드 시도하도록 설정
-
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-        async def run_server():
-            try:
-                # 🔧 Docker 환경에서는 반드시 0.0.0.0으로 바인딩
-                server = await websockets.serve(
-                    handle_openai_websocket,
-                    "0.0.0.0",
-                    free_port,  # localhost → 0.0.0.0
-                )
-                print(
-                    f"[WebSocket] 서버 시작 완료 (OpenAI 모드): ws://0.0.0.0:{free_port}"
-                )
-
-                await server.wait_closed()
-            except Exception as e:
-                print(f"[WebSocket] 서버 실행 오류: {e}")
-                raise e
-
-        loop.run_until_complete(run_server())
-    except Exception as e:
-        print(f"[WebSocket] 서버 시작 오류: {e}")
-        WEBSOCKET_PORT = None
-
-
-# WebSocket 서버를 별도 스레드에서 실행
+# === WebSocket 서버 스레드 ===
 if (
     "websocket_thread" not in st.session_state
     or not st.session_state["websocket_thread"].is_alive()
 ):
-    # 기존 스레드가 있다면 정리
     if "websocket_thread" in st.session_state:
         if st.session_state["websocket_thread"].is_alive():
             print("[WebSocket] 기존 스레드가 여전히 실행 중입니다.")
@@ -886,28 +149,27 @@ if (
             print("[WebSocket] 기존 스레드 정리 중...")
 
     print("[WebSocket] 새로운 WebSocket 스레드 시작 중...")
+    port_ref = st.session_state["websocket_port_ref"]
     st.session_state["websocket_thread"] = threading.Thread(
-        target=start_websocket_server, daemon=True
+        target=start_websocket_server,
+        args=(port_ref,),
+        daemon=True,
     )
     st.session_state["websocket_thread"].start()
     print("[WebSocket] WebSocket 스레드 시작됨")
 
 
-# Session state
+# === Session state ===
 if "action" not in st.session_state:
     st.session_state["action"] = "idle"
 
-# Handle actions
+# === Handle actions ===
 openai_session = None
 if start:
     try:
-        # 사이드바 상태 유지
         st.session_state["sidebar_state"] = "expanded"
 
         with st.spinner("시작 중..."):
-            # OpenAI Realtime API 세션 생성
-            import asyncio
-
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             openai_session = loop.run_until_complete(create_openai_session())
@@ -917,25 +179,21 @@ if start:
             st.session_state["action"] = "start"
             st.rerun()
     except ValueError as e:
-        st.error(f"❌ {str(e)}")
+        st.error(f"❌ {e!s}")
         st.session_state["action"] = "error"
         st.session_state["sidebar_state"] = "expanded"
         st.rerun()
 
 elif stop:
-    # 사이드바 상태 유지
     st.session_state["sidebar_state"] = "expanded"
     st.session_state["action"] = "stop"
     st.session_state.pop("openai_session", None)
     st.rerun()
 
-# 메인 캡션 뷰어
+# === 메인 캡션 뷰어 ===
 try:
     with open("components/webrtc.html", encoding="utf-8") as f:
         html_template = f.read()
-
-    # 현재 사용자 정보 가져오기
-    from auth import get_current_user
 
     current_user = get_current_user()
 
@@ -943,8 +201,8 @@ try:
         "action": st.session_state["action"],
         "openai_session": st.session_state.get("openai_session"),
         "service": "openai_realtime",
-        "websocket_port": WEBSOCKET_PORT,
-        "user_info": current_user,  # 사용자 정보 추가
+        "websocket_port": st.session_state["websocket_port_ref"]["port"],
+        "user_info": current_user,
     }
 
     html_content = html_template.replace("{{BOOTSTRAP_JSON}}", json.dumps(payload))

--- a/components/scroll_lock.html
+++ b/components/scroll_lock.html
@@ -1,0 +1,120 @@
+<style>
+    /* 전체 페이지 스크롤 완전 차단 */
+    html, body {
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100% !important;
+        height: 100vh !important;
+        max-height: 100vh !important;
+        overflow: hidden !important;
+        margin: 0 !important;
+        padding: 0 !important;
+        touch-action: none !important;
+        overscroll-behavior: none !important;
+    }
+
+    /* Streamlit 컨테이너들 스크롤 차단 */
+    .stApp, .main, [data-testid="stAppViewContainer"],
+    [data-testid="stSidebar"], .block-container {
+        position: fixed !important;
+        top: 0 !important;
+        left: 0 !important;
+        width: 100% !important;
+        height: 100vh !important;
+        max-height: 100vh !important;
+        overflow: hidden !important;
+        touch-action: none !important;
+        overscroll-behavior: none !important;
+    }
+
+    /* 추가 스크롤 차단 CSS */
+    * {
+        overflow: hidden !important;
+        touch-action: none !important;
+        overscroll-behavior: none !important;
+    }
+
+    /* iframe 제외하고 모든 요소 스크롤 차단 */
+    *:not(iframe):not(iframe *) {
+        overflow: hidden !important;
+    }
+
+    /* iframe을 전체 화면에 정확히 맞춤 */
+    .main iframe {
+        width: 100% !important;
+        border: none !important;
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+
+    /* 모든 컨테이너 패딩/마진 제거 */
+    .main > div > div {
+        padding-top: 0rem !important;
+        padding-bottom: 0rem !important;
+        margin: 0 !important;
+    }
+
+    /* Streamlit 기본 여백 완전 제거 */
+    .block-container {
+        padding-top: 0rem !important;
+        padding-bottom: 0rem !important;
+        max-height: 100vh !important;
+    }
+
+    /* Streamlit 동적 클래스들의 패딩 완전 제거 */
+    .stMainBlockContainer {
+        padding: 0 !important;
+        margin: 0 !important;
+        height: 100vh !important;
+        max-height: 100vh !important;
+    }
+</style>
+
+<script>
+    // JavaScript로 스크롤 완전 차단
+    function preventScroll(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        return false;
+    }
+
+    // 페이지 로드 후 실행
+    window.addEventListener('load', function() {
+        // 모든 스크롤 이벤트 차단
+        document.addEventListener('wheel', preventScroll, { passive: false });
+        document.addEventListener('touchmove', preventScroll, { passive: false });
+        document.addEventListener('scroll', preventScroll, { passive: false });
+
+        // 스크롤 관련 키 차단
+        document.addEventListener('keydown', function(e) {
+            if([32, 33, 34, 35, 36, 37, 38, 39, 40].indexOf(e.keyCode) > -1) {
+                e.preventDefault();
+            }
+        }, false);
+
+        // 윈도우 스크롤 강제 방지
+        window.addEventListener('scroll', function() {
+            window.scrollTo(0, 0);
+        });
+
+        // 초기 스크롤 위치 고정
+        window.scrollTo(0, 0);
+        document.body.scrollTop = 0;
+        document.documentElement.scrollTop = 0;
+
+        // 사용량 업데이트 메시지 리스너 추가
+        window.addEventListener('message', function(event) {
+            if (event.data && event.data.type === 'usage_update') {
+                console.log('[Usage Listener] 사용량 업데이트 메시지 수신:', event.data);
+                // 짧은 지연 후 페이지 새로고침으로 사이드바 업데이트
+                setTimeout(function() {
+                    // Query parameter를 통해 새로고침 방지
+                    const url = new URL(window.location);
+                    url.searchParams.set('_t', Date.now());
+                    window.location.href = url.toString();
+                }, 1000);
+            }
+        });
+    });
+</script>

--- a/docs/review_lessons.md
+++ b/docs/review_lessons.md
@@ -1,0 +1,68 @@
+# Review Lessons
+
+Preventable patterns identified during code reviews. Each entry includes when the pattern could have been caught earlier.
+
+---
+
+## [RL-001] Copy-paste testing instead of extracting importable modules
+
+- **Category**: Architecture
+- **Frequency**: 2
+- **Observed-In**: PR #8, PR #10 (partially addressed -- modules extracted but tests not yet added)
+- **Description**: When a source file has import side effects (e.g., Streamlit's `st.set_page_config` at module level), test authors copy pure functions into the test file instead of importing them. This creates drift risk -- the copy diverges from the original as the source evolves, producing false coverage.
+- **Prevention**: At kickoff/design time, separate pure logic (port finding, text splitting, API response parsing) into side-effect-free modules. This is a 10-minute refactor that eliminates an entire class of test maintenance bugs.
+- **Recommended action**: Extract pure functions into `utils.py` or similar; import in both `app.py` and tests.
+
+## [RL-002] Trusting client-supplied identity in server-side handlers
+
+- **Category**: Security
+- **Frequency**: 2
+- **Observed-In**: PR #8 review (pre-existing in source), PR #10 (preserved during extraction)
+- **Description**: WebSocket handler accepts user identity (including role) from the first client message without server-side validation. Tests for `check_usage_limit` pass admin-role dicts directly, normalizing the pattern.
+- **Prevention**: During architecture review, require that all identity claims go through server-side session validation. Never trust role/permission claims from client messages.
+- **Recommended action**: Implement token-based WebSocket auth where the server validates session tokens against its own store.
+
+## [RL-003] Deterministic token generation using predictable inputs
+
+- **Category**: Security
+- **Frequency**: 1
+- **Observed-In**: PR #8 review (pre-existing in source)
+- **Description**: Session tokens generated via `SHA-256(user_id:username:timestamp)` are predictable. All inputs are guessable, making the token brute-forceable.
+- **Prevention**: Use `secrets` module for all security tokens. This should be a standard item in security kickoff checklists.
+- **Recommended action**: Replace with `secrets.token_hex()` and store token-to-session mapping server-side.
+
+## [RL-004] Weak test assertions that pass trivially
+
+- **Category**: Testing
+- **Frequency**: 1
+- **Observed-In**: PR #8
+- **Description**: Tests use `assert len(result) >= 1` for functions that split text into multiple parts. This assertion passes even when the function fails to split at all, giving false confidence.
+- **Prevention**: During test review, check that assertions would fail if the function under test did nothing (returned input unchanged). If an assertion passes for both correct and broken implementations, it is too weak.
+- **Recommended action**: Use exact expected values or at minimum assert the expected count of results.
+
+## [RL-005] Refactoring for testability without adding tests
+
+- **Category**: Testing
+- **Frequency**: 1
+- **Observed-In**: PR #10
+- **Description**: A refactoring PR extracts pure functions into importable modules specifically to enable testing, but ships without any tests. The testability improvement is real but unrealized -- the modules can drift or break without detection until someone eventually writes tests.
+- **Prevention**: At PR planning time, pair every "extract for testability" task with a mandatory "add baseline tests" subtask. The tests do not need to be exhaustive -- even 5-10 assertions on the pure functions provide a regression safety net that justifies the refactoring effort.
+- **Recommended action**: Block merge of extraction PRs until at least the pure-function modules (no mocking required) have basic test coverage.
+
+## [RL-006] Internal error details leaked to clients via WebSocket/API responses
+
+- **Category**: Security
+- **Frequency**: 1
+- **Observed-In**: PR #10 review (pre-existing in source, preserved during extraction)
+- **Description**: Exception messages are sent directly to WebSocket clients via `str(e)`. These messages can contain internal file paths, class names, database details, or stack information that aids attackers in reconnaissance.
+- **Prevention**: Establish a project-wide pattern for error responses: log the full error server-side, return a generic message to the client. Add this as a checklist item in the security kickoff.
+- **Recommended action**: Create an error response helper function that maps exceptions to user-safe messages and logs the original error. Apply consistently across all client-facing endpoints.
+
+## [RL-007] Dead code carried forward through refactoring
+
+- **Category**: Code Quality
+- **Frequency**: 1
+- **Observed-In**: PR #10
+- **Description**: Functions that were never called in the original monolith (`create_aws_session`, `start_health_server`) were faithfully extracted into the new module structure. Refactoring is the ideal time to identify and remove dead code, but the mechanical nature of extraction ("move, don't change") can preserve it indefinitely.
+- **Prevention**: During refactoring kickoff, run a dead code analysis (e.g., `vulture` or manual grep for callers) on the original file. Flag uncalled functions for removal or explicit documentation of their intended future use.
+- **Recommended action**: Add a dead code scan step to the refactoring checklist. Functions with no callers should either be removed or annotated with a comment explaining their purpose.

--- a/docs/review_notes_pr10.md
+++ b/docs/review_notes_pr10.md
@@ -1,0 +1,174 @@
+# PR #10 Review Notes -- refactor/extract-app-modules
+
+**Reviewer**: Claude Opus 4.6
+**Date**: 2026-03-19
+**Branch**: `refactor/extract-app-modules`
+**Scope**: Structure-only refactoring -- decompose 955-line `app.py` into focused modules
+**Changed files**: 5 (932 insertions, 810 deletions)
+
+---
+
+## Code Review
+
+### Overall Assessment
+
+The extraction is well-executed. Module boundaries are clean, the import graph is acyclic (`app.py -> services, websocket_handler -> translation, services, auth, database`), and `translation.py` is fully standalone (zero local imports). The `port_ref` dict pattern is a pragmatic solution for cross-thread port sharing.
+
+### Findings
+
+#### [CR-01] `KeyError` on missing `type` field in WebSocket messages (Pre-existing, Blocking)
+
+**File**: `/Users/pillip/project/practice/realtime-en2ko-captions/websocket_handler.py`, line 326
+**What**: `data["type"]` raises `KeyError` if a client sends a JSON message without a `type` field. The generic `except Exception` on line 348 catches it but leaks the `KeyError` message to the client via `str(e)`.
+**Why it matters**: Exposes internal message structure expectations; also, a missing `type` is a normal input edge case, not an exceptional error.
+**Fix**: Use `data.get("type")` instead of `data["type"]`.
+
+```python
+# Before
+if data["type"] == "request_openai_session":
+
+# After
+msg_type = data.get("type")
+if msg_type == "request_openai_session":
+elif msg_type == "transcript":
+```
+
+#### [CR-02] Unreachable `return None` in `_invoke_bedrock_with_fallback` (Low, Suggestion)
+
+**File**: `/Users/pillip/project/practice/realtime-en2ko-captions/translation.py`, line 175
+**What**: The `return None` at the end of `_invoke_bedrock_with_fallback` is unreachable because the last loop iteration re-raises the exception.
+**Fix**: Remove the dead line or restructure so the function always either returns a response or raises.
+
+#### [CR-03] Dead code: `create_aws_session` and `start_health_server` (Low, Suggestion)
+
+**File**: `/Users/pillip/project/practice/realtime-en2ko-captions/services.py`, lines 84-148
+**What**: Both functions are defined but never called anywhere in the codebase. This was pre-existing in the original `app.py`.
+**Why it matters**: Dead code increases maintenance burden and review surface.
+**Fix**: Either remove them or mark them with a comment explaining they are for future/external use. Propose as a follow-up issue.
+
+#### [CR-04] `_clean_llm_response` regex `This.*?:` is overly greedy (Pre-existing, Suggestion)
+
+**File**: `/Users/pillip/project/practice/realtime-en2ko-captions/translation.py`, line 146
+**What**: `re.sub(r"This.*?:", "", ...)` with `re.DOTALL | re.IGNORECASE` will strip any text from "this" to the first colon, which could remove valid translation content (e.g., "This is a demo: 123" becomes " 123").
+**Why it matters**: Could silently truncate legitimate translations.
+**Fix**: Tighten the regex or apply it only before the main content line. Propose as a follow-up issue.
+
+#### [CR-05] No test coverage for any extracted module (Blocking)
+
+**What**: The `tests/` directory is empty. None of the newly extracted modules (`translation.py`, `services.py`, `websocket_handler.py`) have unit tests. The extraction explicitly fixes RL-001 (making functions importable), but the opportunity to add tests was not taken.
+**Why it matters**: The primary benefit of this refactoring is testability. Without tests, there is no regression safety net to verify the extraction preserved behavior.
+**Fix**: At minimum, add tests for `translation.py` (pure functions with no side effects: `detect_language`, `split_into_sentences`, `_clean_llm_response`, `_build_prompt_to_korean`, `_build_prompt_to_english`). These can be written in under 30 minutes and provide real value. Propose as a blocking follow-up.
+
+#### [CR-06] `FileNotFoundError` silently swallowed for `scroll_lock.html` (Low, Suggestion)
+
+**File**: `/Users/pillip/project/practice/realtime-en2ko-captions/app.py`, lines 66-71
+**What**: If `components/scroll_lock.html` is missing, the error is silently passed. This means a deployment issue (missing file) would produce a degraded UI with no indication of what went wrong.
+**Fix**: Log a warning when the file is not found.
+
+#### [CR-07] Event loop lifecycle in `app.py` start handler (Pre-existing, Low)
+
+**File**: `/Users/pillip/project/practice/realtime-en2ko-captions/app.py`, lines 173-176
+**What**: A new event loop is created, used for a single `run_until_complete`, then closed. This pattern works but is fragile -- if `create_openai_session` spawns background tasks, they would be orphaned on `loop.close()`.
+**Fix**: Acceptable for MVP. For robustness, consider `asyncio.run()` (Python 3.7+) which handles cleanup more thoroughly.
+
+### Module Boundary Assessment
+
+| Module | Responsibility | Dependencies | Verdict |
+|--------|---------------|-------------|---------|
+| `app.py` | UI controller, session state, thread management | `auth`, `services`, `websocket_handler` | Clean |
+| `translation.py` | Language detection, sentence splitting, LLM translation | None (pure logic) | Excellent |
+| `services.py` | AWS/OpenAI credential management, session creation | `boto3`, `httpx` | Clean |
+| `websocket_handler.py` | WebSocket server, message routing, transcript handling | `auth`, `database`, `services`, `translation` | Acceptable (hub module) |
+
+`websocket_handler.py` is the heaviest dependency consumer, which is expected as it orchestrates the real-time pipeline.
+
+### Thread Safety Assessment
+
+The `port_ref = {"port": None}` pattern is thread-safe for single-writer (WebSocket thread) / single-reader (Streamlit main thread) under CPython's GIL. Dict value assignment is atomic. This is a correct improvement over the original `global WEBSOCKET_PORT`.
+
+---
+
+## Security Findings
+
+### [SEC-01] Internal exception details leaked to WebSocket clients (Medium)
+
+**File**: `/Users/pillip/project/practice/realtime-en2ko-captions/websocket_handler.py`, line 350
+**What**: `str(e)` is sent directly to the client in error responses. Exception messages can contain internal paths, class names, and stack details.
+**Impact**: Information disclosure that aids attackers in understanding server internals.
+**Exploit path**: Send malformed messages to the WebSocket endpoint; observe error responses for internal information.
+**Pre-existing**: Yes, faithfully extracted from original.
+**Fix**: Return generic error messages to clients; log detailed errors server-side only.
+
+```python
+# Before
+await websocket.send(json.dumps({"type": "error", "message": str(e)}))
+
+# After
+print(f"[WebSocket] message handling error: {e}")
+await websocket.send(json.dumps({"type": "error", "message": "Internal server error"}))
+```
+
+### [SEC-02] WebSocket server binds to 0.0.0.0 without access control (Medium)
+
+**File**: `/Users/pillip/project/practice/realtime-en2ko-captions/websocket_handler.py`, line 376
+**What**: The WebSocket server binds to all interfaces (`0.0.0.0`), making it accessible from any network interface, not just localhost.
+**Impact**: In non-containerized deployments, any machine on the same network can connect to the WebSocket server and bypass the Streamlit authentication layer.
+**Pre-existing**: Yes (comment in original says "Docker requires 0.0.0.0").
+**Fix**: For Docker, bind to `0.0.0.0` only when `DOCKER_ENV` or similar flag is set; default to `127.0.0.1` for local development.
+
+### [SEC-03] `create_aws_session` returns raw AWS secret key in response dict (Medium)
+
+**File**: `/Users/pillip/project/practice/realtime-en2ko-captions/services.py`, line 104
+**What**: `"secret_access_key": AWS_SECRET_ACCESS_KEY` is included in the return value. If this function is ever wired to a client-facing endpoint, long-term AWS credentials would be exposed.
+**Impact**: Currently dead code, so no active exploit path. However, the function name and structure suggest it was designed to be called from a session setup handler.
+**Pre-existing**: Yes.
+**Fix**: Remove `secret_access_key` from the return dict or delete the entire dead function.
+
+### [SEC-04] Client-supplied user identity trusted without server-side validation (Pre-existing, High -- not introduced by this PR)
+
+**File**: `/Users/pillip/project/practice/realtime-en2ko-captions/websocket_handler.py`, lines 46-63
+**What**: `_authenticate_client` accepts whatever the client sends in the `auth` message as the user identity, including `role`. This is documented in RL-002.
+**Status**: Pre-existing. The extraction faithfully preserved this vulnerability. Not blocking for this PR but remains the highest-priority security issue in the codebase.
+
+### [SEC-05] `postMessage` listener in scroll_lock.html does not verify origin (Low)
+
+**File**: `/Users/pillip/project/practice/realtime-en2ko-captions/components/scroll_lock.html`, lines 107-118
+**What**: The `message` event listener checks `event.data.type` but not `event.origin`. Any page (including cross-origin) can trigger a page reload by posting a `usage_update` message.
+**Impact**: Low -- worst case is forcing a page refresh. No data exfiltration.
+**Fix**: Add `event.origin` check:
+
+```javascript
+if (event.origin !== window.location.origin) return;
+```
+
+---
+
+## Severity Summary
+
+| Severity | Count | IDs |
+|----------|-------|-----|
+| Critical | 0 | -- |
+| High | 0 new (1 pre-existing: SEC-04) | -- |
+| Medium | 3 | SEC-01, SEC-02, SEC-03 |
+| Low | 1 | SEC-05 |
+
+---
+
+## Blocking Issues
+
+1. **CR-01**: `data["type"]` KeyError risk -- simple fix, should be done before merge.
+2. **CR-05**: No tests for extracted modules -- at minimum, `translation.py` pure functions should have tests before or immediately after merge.
+
+## Suggested Follow-up Issues
+
+1. Remove dead code (`create_aws_session`, `start_health_server`) or document their intended use.
+2. Fix `_clean_llm_response` overly aggressive regex.
+3. Implement server-side WebSocket authentication (RL-002).
+4. Add origin checking to `postMessage` listener.
+5. Add comprehensive tests for `translation.py`, `services.py` (mocked), and `websocket_handler.py` (mocked).
+
+---
+
+## Confidence Rating: **High**
+
+The PR is a straightforward structural extraction with no behavioral changes. Import graph is verified acyclic. Module boundaries are clean. All security findings are pre-existing. The two blocking items (CR-01 KeyError, CR-05 missing tests) are clear and unambiguous.

--- a/services.py
+++ b/services.py
@@ -1,0 +1,147 @@
+"""
+외부 서비스 세션 관리 모듈
+OpenAI Realtime API, AWS 세션 생성, 헬스체크 서버
+"""
+
+import os
+from datetime import datetime, timedelta
+
+import boto3
+import httpx
+from botocore.exceptions import ClientError
+
+# AWS 설정
+AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY")
+
+# OpenAI 설정
+OPENAI_API_KEY = os.getenv("OPENAI_KEY")
+
+
+async def create_openai_session() -> dict:
+    """OpenAI Realtime API ephemeral token 생성"""
+    if not OPENAI_API_KEY:
+        raise ValueError("OpenAI API 키가 설정되지 않았습니다.")
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                "https://api.openai.com/v1/realtime/sessions",
+                headers={
+                    "Authorization": f"Bearer {OPENAI_API_KEY}",
+                    "Content-Type": "application/json",
+                    "OpenAI-Beta": "realtime=v1",
+                },
+                json={
+                    "model": "gpt-4o-realtime-preview-2024-12-17",
+                    "voice": "alloy",
+                    "instructions": (
+                        "You are a helpful assistant that "
+                        "transcribes audio. Focus on accurate "
+                        "transcription of mixed Korean and "
+                        "English speech, technical terms, and "
+                        "code-switching scenarios."
+                    ),
+                    "input_audio_transcription": {"model": "whisper-1"},
+                    "turn_detection": {
+                        "type": "server_vad",
+                        "threshold": 0.5,
+                        "prefix_padding_ms": 300,
+                        "silence_duration_ms": 500,
+                    },
+                    "modalities": ["audio", "text"],
+                    "temperature": 0.8,
+                },
+            )
+
+            if response.status_code != 200:
+                error_text = response.text
+                print(f"[OpenAI] API 오류: {response.status_code} - {error_text}")
+                raise Exception(f"OpenAI API 오류: {response.status_code}")
+
+            session_data = response.json()
+            expires_at = datetime.now() + timedelta(minutes=1)
+
+            return {
+                "id": session_data.get("id"),
+                "client_secret": session_data.get("client_secret", {}).get("value"),
+                "expires_at": expires_at.isoformat(),
+                "model": session_data.get(
+                    "model",
+                    "gpt-4o-realtime-preview-2024-12-17",
+                ),
+            }
+
+    except httpx.HTTPError as e:
+        print(f"[OpenAI] HTTP 오류: {e}")
+        raise Exception(f"OpenAI 세션 생성 실패: {e}")
+    except Exception as e:
+        print(f"[OpenAI] 예상치 못한 오류: {e}")
+        raise Exception(f"OpenAI 세션 생성 실패: {e}")
+
+
+def create_aws_session(websocket_port=None) -> dict:
+    """AWS 임시 credentials 생성"""
+    if not AWS_ACCESS_KEY_ID or not AWS_SECRET_ACCESS_KEY:
+        raise ValueError("AWS 자격 증명이 설정되지 않았습니다.")
+
+    try:
+        sts_client = boto3.client(
+            "sts",
+            aws_access_key_id=AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+            region_name=AWS_REGION,
+        )
+
+        caller_identity = sts_client.get_caller_identity()
+        ws_port = websocket_port or 8765
+
+        print(f"[AWS Session] WebSocket 포트: {ws_port}")
+
+        return {
+            "access_key_id": AWS_ACCESS_KEY_ID,
+            "secret_access_key": AWS_SECRET_ACCESS_KEY,
+            "region": AWS_REGION,
+            "account_id": caller_identity.get("Account"),
+            "websocket_url": f"ws://localhost:{ws_port}",
+            "openai_available": bool(OPENAI_API_KEY),
+        }
+
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        if error_code == "InvalidUserID.NotFound":
+            raise ValueError("AWS 자격 증명이 유효하지 않습니다.")
+        elif error_code == "TokenRefreshRequired":
+            raise ValueError("AWS 토큰이 만료되었습니다.")
+        else:
+            raise ValueError(f"AWS 연결 실패: {error_code}")
+    except Exception as e:
+        raise ValueError(f"AWS 세션 생성 실패: {e!s}") from e
+
+
+def start_health_server(port):
+    """ALB 헬스체크용 간단한 HTTP 서버"""
+    import http.server
+    import socketserver
+
+    class HealthHandler(http.server.SimpleHTTPRequestHandler):
+        def do_GET(self):
+            if self.path in ["/", "/health"]:
+                self.send_response(200)
+                self.send_header("Content-type", "text/plain")
+                self.end_headers()
+                self.wfile.write(b"OK")
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def log_message(self, format, *args):
+            pass
+
+    try:
+        with socketserver.TCPServer(("0.0.0.0", port), HealthHandler) as httpd:
+            print(f"[Health Check] HTTP 서버 시작: http://0.0.0.0:{port}/health")
+            httpd.serve_forever()
+    except Exception as e:
+        print(f"[Health Check] 서버 오류: {e}")

--- a/translation.py
+++ b/translation.py
@@ -1,0 +1,206 @@
+"""
+번역 서비스 모듈
+LLM 번역, 문장 분리, 언어 감지 기능 제공
+"""
+
+import json
+import re
+
+# 언어 이름 매핑 (한국어 표시용)
+SOURCE_LANG_NAMES = {
+    "en": "영어",
+    "ja": "일본어",
+    "zh": "중국어",
+    "es": "스페인어",
+    "fr": "프랑스어",
+    "de": "독일어",
+}
+
+# Bedrock 모델 ID (안정성 순서)
+BEDROCK_MODEL_IDS = [
+    "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "anthropic.claude-3-haiku-20240307-v1:0",
+    "anthropic.claude-3-sonnet-20240229-v1:0",
+]
+
+
+def detect_language(text):
+    """간단한 한국어 감지 (한글 유니코드 범위 기반)"""
+    has_korean = any(0xAC00 <= ord(c) <= 0xD7A3 for c in text)
+    if has_korean:
+        return "ko", "en"
+    return "en", "ko"
+
+
+def split_into_sentences(text, language="ko"):
+    """텍스트를 문장 단위로 분리"""
+    if language.startswith("ko"):
+        # 한국어 문장 분리 개선
+        # 1. 명확한 문장 종결 패턴
+        text = re.sub(r"([.!?])([가-힣])", r"\1 \2", text)
+
+        # 2. 다양한 종결 어미 고려
+        pattern = (
+            r"(?<=[.!?])"
+            r"|(?<=다)(?=[\s])"
+            r"|(?<=요)(?=[\s.!?])"
+            r"|(?<=까)(?=[\s.!?])"
+            r"|(?<=네)(?=[\s.!?])"
+            r"|(?<=군)(?=[\s.!?])"
+            r"|(?<=나)(?=[\s.!?])"
+        )
+        sentences = re.split(pattern, text)
+
+        # 재결합 및 정리
+        result = []
+        current = ""
+        for sent in sentences:
+            current += sent
+            if re.search(r"[.!?]$|[다요까네군나]$", current.strip()):
+                if current.strip():
+                    result.append(current.strip())
+                current = ""
+        if current.strip():
+            result.append(current.strip())
+        return result
+    else:
+        # 영어 등 문장 분리
+        sentences = re.split(r"(?<=[.!?])\s+", text)
+        return [s.strip() for s in sentences if s.strip()]
+
+
+def _build_prompt_to_korean(text, source_lang):
+    """한국어 번역 프롬프트 생성"""
+    source_lang_name = SOURCE_LANG_NAMES.get(source_lang, "원본 언어")
+    header = (
+        f"다음 {source_lang_name} 텍스트를 "
+        "청중이 듣기 좋은 자연스러운 한국어로 의역해주세요."
+    )
+
+    return f"""{header}
+실시간 컨퍼런스/기술발표 자막으로 사용되며, 완전한 직역보다는 의미 전달이 우선입니다.
+
+원문: "{text}"
+
+번역 가이드라인:
+- 💡 의미 중심: 원문의 핵심 의미를 자연스럽게 전달
+- 🎯 청중 친화적: 듣는 사람이 이해하기 쉬운 한국어 표현
+- 🚀 맥락 반영: 기술발표/비즈니스 상황에 맞는 톤앤매너
+- ⚡ 간결성: 실시간 자막에 적합한 깔끔한 문장 (최대 2문장)
+- 🔧 용어 처리: 기술용어는 한국 개발자들이 실제 사용하는 표현
+- 📝 자연스러움: 한국어 어순과 관용표현 우선, 직역 금지
+
+예시 변환:
+- "Let me walk you through" → "함께 살펴보겠습니다"
+- "It's pretty straightforward" → "사실 꽤 간단합니다"
+- "This is game-changing" → "이건 정말 혁신적이에요"
+- "That landed differently for me" → "제게는 다르게 다가왔습니다"
+
+번역 결과만 출력하세요 (설명, 주석, 부연설명 일절 금지):
+
+한국어 번역:"""
+
+
+def _build_prompt_to_english(text):
+    """영어 번역 프롬프트 생성"""
+    return f"""다음 한국어를 국제 컨퍼런스에서 쓰이는 자연스러운 영어로 의역해주세요.
+글로벌 청중을 위한 실시간 자막으로, 직역보다는 의미가 잘 전달되는 것이 중요합니다.
+
+원문: "{text}"
+
+번역 가이드라인:
+- 🌍 글로벌 표준: 국제 컨퍼런스에서 실제 쓰이는 자연스러운 영어
+- 💼 프로페셔널: 기술발표/비즈니스에 적합한 톤
+- 🎯 명확성: 비영어권 청중도 이해하기 쉬운 표현
+- ⚡ 간결성: 자막에 적합한 깔끔한 문장
+- 🔧 용어 활용: 업계 표준 기술용어 및 표현 사용
+
+예시 변환:
+- "이걸 한번 보시면" → "Let's take a look at this"
+- "꽤 괜찮은 것 같아요" → "This looks pretty promising"
+- "정말 대단한 기술이에요" → "This is truly impressive technology"
+
+번역 결과만 출력하세요 (설명, 주석, 부연설명 일절 금지):
+
+English translation:"""
+
+
+def _clean_llm_response(translated_text):
+    """LLM 응답에서 불필요한 텍스트 제거"""
+    translated_text = translated_text.strip("\"'")
+
+    # 설명 텍스트 제거
+    translated_text = re.sub(
+        r"This translation:.*$",
+        "",
+        translated_text,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    translated_text = re.sub(
+        r"Here\'s a natural.*?:",
+        "",
+        translated_text,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    translated_text = re.sub(
+        r"This.*?:", "", translated_text, flags=re.DOTALL | re.IGNORECASE
+    )
+
+    # 첫 번째 줄만 추출
+    lines = translated_text.split("\n")
+    if lines:
+        translated_text = lines[0].strip()
+
+    # 따옴표 제거
+    translated_text = re.sub(r'^["\'](.+)["\']$', r"\1", translated_text)
+
+    return translated_text.strip()
+
+
+def _invoke_bedrock_with_fallback(bedrock_client, body):
+    """여러 모델을 시도하며 Bedrock 호출"""
+    for model_id in BEDROCK_MODEL_IDS:
+        try:
+            response = bedrock_client.invoke_model(
+                modelId=model_id,
+                body=body,
+                contentType="application/json",
+                accept="application/json",
+            )
+            return response
+        except Exception as model_error:
+            print(f"    ⚠️ {model_id} 모델 실패: {model_error}")
+            if model_id == BEDROCK_MODEL_IDS[-1]:
+                raise model_error
+    return None
+
+
+def translate_with_llm(bedrock_client, text, source_lang, target_lang):
+    """Bedrock LLM을 사용한 고품질 컨텍스트 번역"""
+    try:
+        if target_lang == "ko":
+            prompt = _build_prompt_to_korean(text, source_lang)
+        else:
+            prompt = _build_prompt_to_english(text)
+
+        body = json.dumps(
+            {
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 200,
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": prompt}]}
+                ],
+                "temperature": 0.5,
+                "top_p": 0.9,
+            }
+        )
+
+        response = _invoke_bedrock_with_fallback(bedrock_client, body)
+        response_body = json.loads(response["body"].read())
+        translated_text = response_body["content"][0]["text"].strip()
+
+        return _clean_llm_response(translated_text)
+
+    except Exception as e:
+        print(f"    ❌ LLM 번역 실패: {e}")
+        return None

--- a/websocket_handler.py
+++ b/websocket_handler.py
@@ -323,10 +323,11 @@ async def handle_openai_websocket(websocket):
             try:
                 data = json.loads(message)
 
-                if data["type"] == "request_openai_session":
+                msg_type = data.get("type")
+                if msg_type == "request_openai_session":
                     await _handle_session_request(websocket)
 
-                elif data["type"] == "transcript":
+                elif msg_type == "transcript":
                     await _handle_transcript(
                         websocket,
                         data,

--- a/websocket_handler.py
+++ b/websocket_handler.py
@@ -1,0 +1,391 @@
+"""
+WebSocket 서버 및 핸들러 모듈
+OpenAI Realtime API 통합, 번역 처리, 사용량 추적
+"""
+
+import asyncio
+import json
+import socket
+import time
+
+import boto3
+import websockets
+
+from auth import check_usage_limit, update_user_session
+from database import get_usage_log_model, get_user_model
+from services import (
+    AWS_ACCESS_KEY_ID,
+    AWS_REGION,
+    AWS_SECRET_ACCESS_KEY,
+    create_openai_session,
+)
+from translation import detect_language, translate_with_llm
+
+
+def find_free_port(start_port=8765, max_port=8800):
+    """동적으로 사용 가능한 포트 찾기"""
+    for port in range(start_port, max_port + 1):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("localhost", port))
+                print(f"[Port] 포트 {port} 사용 가능")
+                return port
+        except OSError:
+            continue
+
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("localhost", 0))
+            port = s.getsockname()[1]
+            print(f"[Port] OS 자동 할당 포트: {port}")
+            return port
+    except OSError:
+        raise Exception("사용 가능한 포트를 찾을 수 없습니다")
+
+
+async def _authenticate_client(websocket):
+    """WebSocket 클라이언트 인증 처리"""
+    try:
+        first_message = await asyncio.wait_for(websocket.recv(), timeout=5.0)
+        data = json.loads(first_message)
+        if data.get("type") == "auth":
+            user_info = data.get("user")
+            username = user_info.get("username") if user_info else "Unknown"
+            print(f"[Auth] 사용자 인증: {username}")
+            await websocket.send(
+                json.dumps({"type": "auth_success", "message": "인증 완료"})
+            )
+            return user_info
+    except TimeoutError:
+        print("[Auth] 인증 정보 수신 타임아웃")
+    except Exception as e:
+        print(f"[Auth] 인증 처리 오류: {e}")
+    return None
+
+
+def _init_translation_clients():
+    """번역용 AWS 클라이언트 초기화"""
+    translate_client = boto3.client(
+        "translate",
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+        region_name=AWS_REGION,
+    )
+
+    bedrock_client = None
+    bedrock_available = False
+    try:
+        bedrock_client = boto3.client(
+            "bedrock-runtime",
+            aws_access_key_id=AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+            region_name=AWS_REGION,
+        )
+        bedrock_available = True
+        print("  🤖 Bedrock LLM 준비 완료")
+    except Exception:
+        print("  ⚠️ Bedrock 사용 불가, AWS Translate 사용")
+
+    return translate_client, bedrock_client, bedrock_available
+
+
+async def _handle_session_request(websocket):
+    """OpenAI 세션 요청 처리"""
+    try:
+        session = await create_openai_session()
+        await websocket.send(json.dumps({"type": "openai_session", "session": session}))
+        print("[OpenAI] ✅ 세션 생성 완료")
+    except Exception as e:
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "error",
+                    "message": f"OpenAI 세션 생성 실패: {e!s}",
+                }
+            )
+        )
+        print(f"[OpenAI] ❌ 세션 생성 실패: {e}")
+
+
+def _translate_text(
+    transcript,
+    source_lang,
+    target_lang,
+    translate_client,
+    bedrock_client,
+    bedrock_available,
+):
+    """텍스트 번역 (LLM 우선, AWS Translate 폴백)"""
+    translated_text = None
+    used_llm = False
+
+    if bedrock_available:
+        try:
+            translated_text = translate_with_llm(
+                bedrock_client,
+                transcript,
+                source_lang,
+                target_lang,
+            )
+            if translated_text:
+                used_llm = True
+                print("[Translate] ✅ LLM 번역 완료")
+        except Exception:
+            pass
+
+    if not translated_text:
+        try:
+            response = translate_client.translate_text(
+                Text=transcript,
+                SourceLanguageCode=source_lang,
+                TargetLanguageCode=target_lang,
+            )
+            translated_text = response["TranslatedText"]
+            print("[Translate] ✅ AWS Translate 완료")
+        except Exception as e:
+            print(f"[Translate] ❌ 번역 실패: {e}")
+            translated_text = transcript
+
+    return translated_text, used_llm
+
+
+def _record_usage(
+    current_user,
+    audio_duration,
+    data,
+    transcript,
+    translated_text,
+    used_llm,
+    source_lang,
+    target_lang,
+):
+    """사용량 기록"""
+    try:
+        user_model = get_user_model()
+        usage_log_model = get_usage_log_model()
+
+        if audio_duration <= 0:
+            audio_duration = max(1, len(transcript) / 5.0)
+            print(f"[Usage] 📏 텍스트 기반 추정: {audio_duration:.1f}초")
+
+        user_model.add_usage(current_user["id"], int(audio_duration))
+
+        usage_log_model.record_usage(
+            user_id=current_user["id"],
+            action="transcribe",
+            duration_seconds=int(audio_duration),
+            source_language=source_lang,
+            target_language=target_lang,
+            metadata={
+                "transcript_length": len(transcript),
+                "translated_length": (len(translated_text) if translated_text else 0),
+                "used_llm": used_llm,
+                "estimated": audio_duration != data.get("audio_duration_seconds", 0),
+                "source_text": transcript,
+                "target_text": translated_text,
+            },
+        )
+
+        update_user_session(current_user["id"])
+
+        print(
+            f"[Usage] ✅ 사용량 기록 - "
+            f"User: {current_user['username']}, "
+            f"Duration: {audio_duration}초"
+        )
+        return audio_duration
+
+    except Exception as e:
+        print(f"[Usage] ❌ 사용량 기록 실패: {e}")
+        return audio_duration
+
+
+async def _handle_transcript(
+    websocket,
+    data,
+    user_info,
+    translate_client,
+    bedrock_client,
+    bedrock_available,
+):
+    """트랜스크립트 메시지 처리 (번역 + 사용량)"""
+    transcript = data.get("text", "")
+    audio_duration = data.get("audio_duration_seconds", 0)
+
+    if not transcript:
+        return
+
+    print(f"[OpenAI] 📝 Transcript: {transcript}")
+    print(f"[Usage] 🔊 Audio duration: {audio_duration} seconds")
+
+    current_user = user_info
+    if not current_user:
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "error",
+                    "message": (
+                        "로그인이 필요합니다. "
+                        "페이지를 새로고침하고 "
+                        "다시 로그인해주세요."
+                    ),
+                }
+            )
+        )
+        return
+
+    if not check_usage_limit(audio_duration, current_user):
+        user_model = get_user_model()
+        remaining = user_model.get_remaining_seconds(current_user["id"])
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "usage_exceeded",
+                    "message": (f"사용량이 초과되었습니다. 남은 시간: {remaining}초"),
+                    "remaining_seconds": remaining or 0,
+                }
+            )
+        )
+        print(
+            f"[Usage] ❌ 사용량 초과 - "
+            f"User: {current_user['username']}, "
+            f"Remaining: {remaining}초"
+        )
+        return
+
+    source_lang, target_lang = detect_language(transcript)
+
+    translated_text, used_llm = _translate_text(
+        transcript,
+        source_lang,
+        target_lang,
+        translate_client,
+        bedrock_client,
+        bedrock_available,
+    )
+
+    audio_duration = _record_usage(
+        current_user,
+        audio_duration,
+        data,
+        transcript,
+        translated_text,
+        used_llm,
+        source_lang,
+        target_lang,
+    )
+
+    user_model = get_user_model()
+    remaining_seconds = user_model.get_remaining_seconds(current_user["id"])
+
+    await websocket.send(
+        json.dumps(
+            {
+                "type": "transcription_result",
+                "original_text": transcript,
+                "translated_text": translated_text,
+                "source_language": source_lang,
+                "target_language": target_lang,
+                "used_llm": used_llm,
+                "audio_duration": audio_duration,
+                "timestamp": time.time(),
+                "remaining_seconds": remaining_seconds,
+                "user_id": current_user["id"],
+            }
+        )
+    )
+
+
+async def handle_openai_websocket(websocket):
+    """OpenAI Realtime API와 통합된 WebSocket 핸들러"""
+    print(f"[WebSocket] OpenAI 모드 - 클라이언트 연결: {websocket.remote_address}")
+
+    user_info = await _authenticate_client(websocket)
+
+    try:
+        (
+            translate_client,
+            bedrock_client,
+            bedrock_available,
+        ) = _init_translation_clients()
+
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "connection",
+                    "status": "connected",
+                    "message": "OpenAI Realtime + 번역 서비스 준비",
+                }
+            )
+        )
+
+        async for message in websocket:
+            try:
+                data = json.loads(message)
+
+                if data["type"] == "request_openai_session":
+                    await _handle_session_request(websocket)
+
+                elif data["type"] == "transcript":
+                    await _handle_transcript(
+                        websocket,
+                        data,
+                        user_info,
+                        translate_client,
+                        bedrock_client,
+                        bedrock_available,
+                    )
+
+            except json.JSONDecodeError:
+                await websocket.send(
+                    json.dumps(
+                        {
+                            "type": "error",
+                            "message": "Invalid JSON format",
+                        }
+                    )
+                )
+            except Exception as e:
+                print(f"[WebSocket] 메시지 처리 오류: {e}")
+                await websocket.send(json.dumps({"type": "error", "message": str(e)}))
+
+    except Exception as e:
+        print(f"[WebSocket] 연결 오류: {e}")
+    finally:
+        print("[WebSocket] 클라이언트 연결 종료")
+
+
+def start_websocket_server(port_ref):
+    """WebSocket 서버 시작 (동적 포트 할당)
+
+    Args:
+        port_ref: 포트를 저장할 dict ({"port": None})
+    """
+    try:
+        free_port = find_free_port()
+        print(f"[WebSocket] 할당된 포트: {free_port}")
+        port_ref["port"] = free_port
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+        async def run_server():
+            try:
+                server = await websockets.serve(
+                    handle_openai_websocket,
+                    "0.0.0.0",
+                    free_port,
+                )
+                print(
+                    f"[WebSocket] 서버 시작 완료 (OpenAI 모드): "
+                    f"ws://0.0.0.0:{free_port}"
+                )
+                await server.wait_closed()
+            except Exception as e:
+                print(f"[WebSocket] 서버 실행 오류: {e}")
+                raise e
+
+        loop.run_until_complete(run_server())
+    except Exception as e:
+        print(f"[WebSocket] 서버 시작 오류: {e}")
+        port_ref["port"] = None


### PR DESCRIPTION
## Summary
- Decomposed 955-line `app.py` God file into 4 focused modules: `translation.py`, `services.py`, `websocket_handler.py`, `components/scroll_lock.html`
- Replaced global `WEBSOCKET_PORT` variable with thread-safe dict ref pattern
- `app.py` reduced to ~213 lines as a slim UI controller

## Changes
| File | Description |
|------|-------------|
| `translation.py` | LLM translation, language detection, sentence splitting |
| `services.py` | OpenAI/AWS session management, health check server |
| `websocket_handler.py` | WebSocket server + decomposed handler (auth, translate, usage) |
| `components/scroll_lock.html` | Extracted 120+ lines of inline CSS/JS |
| `app.py` | Slim UI controller importing from new modules |

## Test plan
- [x] All modules import successfully (`import translation; import services; import websocket_handler`)
- [x] Ruff lint passes on all files
- [x] Pre-commit hooks pass
- [ ] Manual smoke test: start app, verify captions work end-to-end

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)