### PR TITLE
fix(security): replace deterministic session token with CSPRNG

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -4,7 +4,7 @@ Streamlit session_state를 활용한 사용자 인증 및 권한 관리
 extra-streamlit-components의 CookieManager로 세션 관리
 """
 
-import hashlib
+import secrets
 import time
 from collections.abc import Callable
 from functools import wraps
@@ -28,10 +28,8 @@ def get_cookie_manager():
 
 
 def generate_session_token(user_id: int, username: str) -> str:
-    """세션 토큰 생성"""
-    timestamp = str(int(time.time()))
-    data = f"{user_id}:{username}:{timestamp}"
-    return hashlib.sha256(data.encode()).hexdigest()[:32]
+    """세션 토큰 생성 (CSPRNG 기반)"""
+    return secrets.token_hex(32)
 
 
 def set_session_cookie(user_info: dict):

--- a/tests/test_auth_module.py
+++ b/tests/test_auth_module.py
@@ -109,12 +109,20 @@ class TestGenerateSessionToken:
         token = generate_session_token(1, "testuser")
         assert isinstance(token, str)
 
-    def test_token_length(self):
-        """토큰 길이가 32자"""
+    def test_token_length_64_hex(self):
+        """토큰 길이가 64자 (secrets.token_hex(32))"""
         from auth import generate_session_token
 
         token = generate_session_token(1, "testuser")
-        assert len(token) == 32
+        assert len(token) == 64
+
+    def test_same_user_same_second_different_tokens(self):
+        """같은 사용자, 같은 초에 생성해도 다른 토큰"""
+        from auth import generate_session_token
+
+        token1 = generate_session_token(1, "testuser")
+        token2 = generate_session_token(1, "testuser")
+        assert token1 != token2
 
     def test_different_users_different_tokens(self):
         """다른 사용자는 다른 토큰 생성"""
@@ -129,7 +137,6 @@ class TestGenerateSessionToken:
         from auth import generate_session_token
 
         token = generate_session_token(1, "testuser")
-        # 16진수 변환 가능해야 함
         int(token, 16)
 
 


### PR DESCRIPTION
## Summary
- Replace `hashlib.sha256(user_id:username:timestamp)` with `secrets.token_hex(32)`
- Eliminates same-second collisions and makes token forgery infeasible
- Update tests to assert uniqueness instead of determinism

Closes ISSUE-9

## Test plan
- [x] `uv run pytest tests/test_auth_module.py -q` — 36 passed
- [x] Two tokens for same user in same second are different

🤖 Generated with [Claude Code](https://claude.com/claude-code)