### PR TITLE
feat(db): add indexes on usage_logs.user_id and created_at

### DIFF
--- a/database.py
+++ b/database.py
@@ -74,6 +74,20 @@ class DatabaseManager:
             """
             )
 
+            # usage_logs 인덱스 생성 (조회 성능 개선)
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_usage_logs_user_id
+                ON usage_logs(user_id)
+            """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_usage_logs_created_at
+                ON usage_logs(created_at)
+            """
+            )
+
             conn.commit()
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -453,3 +453,43 @@ class TestForeignKeyEnforcement:
 
         logs = usage_log.get_user_logs(sample_user)
         assert len(logs) == 0
+
+
+# === Index Tests (ISSUE-13) ===
+
+
+class TestUsageLogsIndexes:
+    """usage_logs 테이블 인덱스 검증"""
+
+    def test_user_id_index_exists(self, db_manager):
+        """idx_usage_logs_user_id 인덱스 존재 확인"""
+        with db_manager.get_connection() as conn:
+            cursor = conn.execute("PRAGMA index_list('usage_logs')")
+            indexes = {row["name"] for row in cursor.fetchall()}
+        assert "idx_usage_logs_user_id" in indexes
+
+    def test_created_at_index_exists(self, db_manager):
+        """idx_usage_logs_created_at 인덱스 존재 확인"""
+        with db_manager.get_connection() as conn:
+            cursor = conn.execute("PRAGMA index_list('usage_logs')")
+            indexes = {row["name"] for row in cursor.fetchall()}
+        assert "idx_usage_logs_created_at" in indexes
+
+    def test_indexes_idempotent(self, db_manager):
+        """init_database 재실행 시 인덱스 중복 생성 없음"""
+        db_manager.init_database()  # 두 번째 호출
+        with db_manager.get_connection() as conn:
+            cursor = conn.execute("PRAGMA index_list('usage_logs')")
+            index_names = [row["name"] for row in cursor.fetchall()]
+        # 중복 인덱스 없음
+        assert index_names.count("idx_usage_logs_user_id") == 1
+        assert index_names.count("idx_usage_logs_created_at") == 1
+
+    def test_existing_tests_pass_with_indexes(self, db_manager, sample_user):
+        """인덱스 추가 후 기존 usage_logs 작업 정상 동작"""
+        usage_log = UsageLog(db_manager)
+        log_id = usage_log.record_usage(sample_user, "transcribe", 30)
+        assert log_id is not None
+
+        logs = usage_log.get_user_logs(sample_user)
+        assert len(logs) == 1


### PR DESCRIPTION
## Summary
- Add `idx_usage_logs_user_id` and `idx_usage_logs_created_at` indexes in `init_database()` (ISSUE-13)
- Uses `CREATE INDEX IF NOT EXISTS` for idempotent re-initialization
- Improves query performance for user-based and time-based log lookups

## Test plan
- [x] PRAGMA index_list returns both indexes after init
- [x] Re-running init_database does not create duplicate indexes
- [x] Existing usage_logs operations work with indexes
- [x] All 190 tests pass

Closes #13

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>