### PR TITLE
test(admin): add unit tests for admin business logic

### DIFF
--- a/admin_logic.py
+++ b/admin_logic.py
@@ -1,0 +1,113 @@
+"""
+admin.py에서 추출한 순수 비즈니스 로직 함수들
+Streamlit 의존성 없이 테스트 가능
+"""
+
+import csv
+import io
+
+
+def validate_password(password: str, confirm: str) -> tuple[bool, str]:
+    """비밀번호 유효성 검증
+
+    Args:
+        password: 입력된 비밀번호
+        confirm: 확인용 비밀번호
+
+    Returns:
+        (valid, error_message) 튜플. valid가 True이면 error_message는 빈 문자열.
+    """
+    if not password:
+        return False, "비밀번호는 필수입니다."
+    if len(password) < 6:
+        return False, "비밀번호는 최소 6자 이상이어야 합니다."
+    if password != confirm:
+        return False, "비밀번호가 일치하지 않습니다."
+    return True, ""
+
+
+def prepare_user_table_data(users: list[dict], get_remaining_seconds_fn) -> list[dict]:
+    """사용자 목록을 테이블 표시용 데이터로 변환
+
+    Args:
+        users: 사용자 딕셔너리 리스트 (DB 조회 결과)
+        get_remaining_seconds_fn: user_id를 받아 남은 초를 반환하는 함수
+
+    Returns:
+        테이블 표시용 딕셔너리 리스트
+    """
+    result = []
+    for user in users:
+        remaining_seconds = get_remaining_seconds_fn(user["id"])
+        remaining_minutes = (
+            remaining_seconds / 60 if remaining_seconds is not None else 0
+        )
+
+        result.append(
+            {
+                "ID": user["id"],
+                "사용자명": user["username"],
+                "소속": user["full_name"] or "-",
+                "이메일": user["email"] or "-",
+                "역할": user["role"],
+                "상태": "활성" if user["is_active"] else "비활성",
+                "사용량(초)": user["total_usage_seconds"],
+                "제한(초)": user["usage_limit_seconds"],
+                "남은시간(분)": f"{remaining_minutes:.1f}",
+                "생성일": user["created_at"],
+                "최근로그인": user["last_login"] or "-",
+            }
+        )
+    return result
+
+
+def export_user_logs_csv(logs: list[dict], username: str) -> bytes:
+    """사용자 로그를 CSV 바이트로 변환 (BOM 포함, UTF-8)
+
+    Args:
+        logs: 로그 딕셔너리 리스트
+        username: 사용자명 (파일명에 사용)
+
+    Returns:
+        UTF-8 BOM이 포함된 CSV 바이트 데이터
+    """
+    CSV_HEADERS = [
+        "ID",
+        "사용자ID",
+        "작업",
+        "시간(초)",
+        "소스언어",
+        "대상언어",
+        "원문",
+        "번역문",
+        "생성일시",
+        "메타데이터",
+    ]
+
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=CSV_HEADERS)
+    writer.writeheader()
+
+    for log in logs:
+        metadata = log.get("metadata", {})
+        source_text = metadata.get("source_text", "") if metadata else ""
+        target_text = metadata.get("target_text", "") if metadata else ""
+
+        writer.writerow(
+            {
+                "ID": log["id"],
+                "사용자ID": log["user_id"],
+                "작업": log["action"],
+                "시간(초)": log["duration_seconds"],
+                "소스언어": log["source_language"] or "",
+                "대상언어": log["target_language"] or "",
+                "원문": source_text,
+                "번역문": target_text,
+                "생성일시": log["created_at"],
+                "메타데이터": str(metadata) if metadata else "",
+            }
+        )
+
+    csv_string = output.getvalue()
+    # BOM + UTF-8 encoding
+    return b"\xef\xbb\xbf" + csv_string.encode("utf-8")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,335 @@
+"""
+admin_logic.py 비즈니스 로직 단위 테스트
+validate_password, prepare_user_table_data, export_user_logs_csv 함수 테스트
+"""
+
+import csv
+import io
+
+import pytest
+
+from admin_logic import export_user_logs_csv, prepare_user_table_data, validate_password
+
+
+# ============================================================
+# validate_password 테스트
+# ============================================================
+class TestValidatePassword:
+    """validate_password 함수 테스트"""
+
+    def test_valid_password(self):
+        """유효한 비밀번호와 일치하는 확인 -> (True, '')"""
+        valid, msg = validate_password("secure123", "secure123")
+        assert valid is True
+        assert msg == ""
+
+    def test_empty_password(self):
+        """빈 비밀번호 -> (False, 에러 메시지)"""
+        valid, msg = validate_password("", "")
+        assert valid is False
+        assert "필수" in msg
+
+    def test_password_too_short(self):
+        """6자 미만 비밀번호 -> (False, 에러 메시지)"""
+        valid, msg = validate_password("abc12", "abc12")
+        assert valid is False
+        assert "6자" in msg
+
+    def test_password_exactly_6_chars(self):
+        """정확히 6자 비밀번호 -> (True, '')"""
+        valid, msg = validate_password("abc123", "abc123")
+        assert valid is True
+        assert msg == ""
+
+    def test_password_mismatch(self):
+        """비밀번호 불일치 -> (False, 에러 메시지)"""
+        valid, msg = validate_password("secure123", "secure456")
+        assert valid is False
+        assert "일치" in msg
+
+    def test_short_password_checked_before_mismatch(self):
+        """짧은 비밀번호는 불일치 확인보다 먼저 체크"""
+        valid, msg = validate_password("abc", "xyz")
+        assert valid is False
+        assert "6자" in msg
+
+    def test_password_5_chars(self):
+        """5자 비밀번호 -> (False, 에러 메시지)"""
+        valid, msg = validate_password("12345", "12345")
+        assert valid is False
+        assert "6자" in msg
+
+    def test_long_password(self):
+        """긴 비밀번호도 통과"""
+        long_pass = "a" * 100
+        valid, msg = validate_password(long_pass, long_pass)
+        assert valid is True
+        assert msg == ""
+
+
+# ============================================================
+# prepare_user_table_data 테스트
+# ============================================================
+class TestPrepareUserTableData:
+    """prepare_user_table_data 함수 테스트"""
+
+    @pytest.fixture
+    def sample_users(self):
+        """테스트용 사용자 데이터"""
+        return [
+            {
+                "id": 1,
+                "username": "user1",
+                "full_name": "User One",
+                "email": "user1@example.com",
+                "role": "user",
+                "is_active": True,
+                "total_usage_seconds": 1800,
+                "usage_limit_seconds": 3600,
+                "created_at": "2026-01-01",
+                "last_login": "2026-04-01",
+            },
+            {
+                "id": 2,
+                "username": "admin1",
+                "full_name": None,
+                "email": None,
+                "role": "admin",
+                "is_active": True,
+                "total_usage_seconds": 0,
+                "usage_limit_seconds": 0,
+                "created_at": "2026-01-01",
+                "last_login": None,
+            },
+            {
+                "id": 3,
+                "username": "inactive_user",
+                "full_name": "Inactive",
+                "email": "inactive@test.com",
+                "role": "user",
+                "is_active": False,
+                "total_usage_seconds": 500,
+                "usage_limit_seconds": 3600,
+                "created_at": "2026-02-01",
+                "last_login": "2026-03-01",
+            },
+        ]
+
+    def test_basic_conversion(self, sample_users):
+        """기본 변환: 사용자 수만큼 행 반환"""
+        result = prepare_user_table_data(
+            sample_users, lambda uid: 1800 if uid == 1 else 0
+        )
+        assert len(result) == 3
+
+    def test_remaining_minutes_calculation(self, sample_users):
+        """남은시간(분) 올바른 계산"""
+        result = prepare_user_table_data(
+            sample_users, lambda uid: 1800 if uid == 1 else 0
+        )
+        # 1800초 = 30.0분
+        assert result[0]["남은시간(분)"] == "30.0"
+
+    def test_remaining_seconds_none_returns_zero(self, sample_users):
+        """get_remaining_seconds가 None 반환 시 0분"""
+        result = prepare_user_table_data(sample_users, lambda uid: None)
+        assert result[0]["남은시간(분)"] == "0.0"
+
+    def test_null_full_name_shows_dash(self, sample_users):
+        """full_name이 None이면 '-' 표시"""
+        result = prepare_user_table_data(sample_users, lambda uid: 0)
+        assert result[1]["소속"] == "-"
+
+    def test_null_email_shows_dash(self, sample_users):
+        """email이 None이면 '-' 표시"""
+        result = prepare_user_table_data(sample_users, lambda uid: 0)
+        assert result[1]["이메일"] == "-"
+
+    def test_null_last_login_shows_dash(self, sample_users):
+        """last_login이 None이면 '-' 표시"""
+        result = prepare_user_table_data(sample_users, lambda uid: 0)
+        assert result[1]["최근로그인"] == "-"
+
+    def test_active_user_status(self, sample_users):
+        """활성 사용자 상태 표시"""
+        result = prepare_user_table_data(sample_users, lambda uid: 0)
+        assert result[0]["상태"] == "활성"
+
+    def test_inactive_user_status(self, sample_users):
+        """비활성 사용자 상태 표시"""
+        result = prepare_user_table_data(sample_users, lambda uid: 0)
+        assert result[2]["상태"] == "비활성"
+
+    def test_empty_users_list(self):
+        """빈 사용자 리스트 -> 빈 결과"""
+        result = prepare_user_table_data([], lambda uid: 0)
+        assert result == []
+
+    def test_preserves_user_fields(self, sample_users):
+        """사용자 필드가 올바르게 매핑"""
+        result = prepare_user_table_data(sample_users, lambda uid: 0)
+        assert result[0]["ID"] == 1
+        assert result[0]["사용자명"] == "user1"
+        assert result[0]["역할"] == "user"
+        assert result[0]["사용량(초)"] == 1800
+        assert result[0]["제한(초)"] == 3600
+        assert result[0]["생성일"] == "2026-01-01"
+
+    def test_fractional_remaining_minutes(self, sample_users):
+        """소수점 잔여 시간 계산"""
+        # 90초 = 1.5분
+        result = prepare_user_table_data([sample_users[0]], lambda uid: 90)
+        assert result[0]["남은시간(분)"] == "1.5"
+
+
+# ============================================================
+# export_user_logs_csv 테스트
+# ============================================================
+class TestExportUserLogsCsv:
+    """export_user_logs_csv 함수 테스트"""
+
+    @pytest.fixture
+    def sample_logs(self):
+        """테스트용 로그 데이터"""
+        return [
+            {
+                "id": 1,
+                "user_id": 10,
+                "action": "transcription",
+                "duration_seconds": 30,
+                "source_language": "en",
+                "target_language": "ko",
+                "created_at": "2026-04-28T10:00:00",
+                "metadata": {
+                    "source_text": "Hello world",
+                    "target_text": "안녕하세요 세계",
+                },
+            },
+            {
+                "id": 2,
+                "user_id": 10,
+                "action": "transcription",
+                "duration_seconds": 15,
+                "source_language": "ko",
+                "target_language": "en",
+                "created_at": "2026-04-28T10:01:00",
+                "metadata": None,
+            },
+        ]
+
+    def test_csv_starts_with_bom(self, sample_logs):
+        """CSV 출력이 UTF-8 BOM으로 시작"""
+        result = export_user_logs_csv(sample_logs, "testuser")
+        assert result[:3] == b"\xef\xbb\xbf"
+
+    def test_csv_returns_bytes(self, sample_logs):
+        """반환값이 bytes 타입"""
+        result = export_user_logs_csv(sample_logs, "testuser")
+        assert isinstance(result, bytes)
+
+    def test_csv_has_correct_headers(self, sample_logs):
+        """CSV에 올바른 헤더가 포함"""
+        result = export_user_logs_csv(sample_logs, "testuser")
+        # BOM 제거 후 디코딩
+        csv_text = result[3:].decode("utf-8")
+        reader = csv.reader(io.StringIO(csv_text))
+        headers = next(reader)
+        expected_headers = [
+            "ID",
+            "사용자ID",
+            "작업",
+            "시간(초)",
+            "소스언어",
+            "대상언어",
+            "원문",
+            "번역문",
+            "생성일시",
+            "메타데이터",
+        ]
+        assert headers == expected_headers
+
+    def test_csv_row_count(self, sample_logs):
+        """CSV 행 수 = 헤더 1 + 로그 수"""
+        result = export_user_logs_csv(sample_logs, "testuser")
+        csv_text = result[3:].decode("utf-8")
+        reader = csv.reader(io.StringIO(csv_text))
+        rows = list(reader)
+        assert len(rows) == 3  # 1 header + 2 data rows
+
+    def test_csv_data_correct_values(self, sample_logs):
+        """CSV 데이터 값 검증"""
+        result = export_user_logs_csv(sample_logs, "testuser")
+        csv_text = result[3:].decode("utf-8")
+        reader = csv.DictReader(io.StringIO(csv_text))
+        rows = list(reader)
+
+        assert rows[0]["ID"] == "1"
+        assert rows[0]["사용자ID"] == "10"
+        assert rows[0]["작업"] == "transcription"
+        assert rows[0]["시간(초)"] == "30"
+        assert rows[0]["소스언어"] == "en"
+        assert rows[0]["대상언어"] == "ko"
+        assert rows[0]["원문"] == "Hello world"
+        assert rows[0]["번역문"] == "안녕하세요 세계"
+
+    def test_csv_metadata_none_handled(self, sample_logs):
+        """metadata가 None인 로그도 처리"""
+        result = export_user_logs_csv(sample_logs, "testuser")
+        csv_text = result[3:].decode("utf-8")
+        reader = csv.DictReader(io.StringIO(csv_text))
+        rows = list(reader)
+
+        # metadata가 None인 두 번째 로그
+        assert rows[1]["원문"] == ""
+        assert rows[1]["번역문"] == ""
+        assert rows[1]["메타데이터"] == ""
+
+    def test_csv_empty_logs(self):
+        """빈 로그 리스트 -> 헤더만 포함된 CSV"""
+        result = export_user_logs_csv([], "testuser")
+        csv_text = result[3:].decode("utf-8")
+        reader = csv.reader(io.StringIO(csv_text))
+        rows = list(reader)
+        assert len(rows) == 1  # header only
+
+    def test_csv_null_language_fields(self):
+        """source_language/target_language가 None인 경우 빈 문자열"""
+        logs = [
+            {
+                "id": 1,
+                "user_id": 10,
+                "action": "transcription",
+                "duration_seconds": 5,
+                "source_language": None,
+                "target_language": None,
+                "created_at": "2026-04-28T10:00:00",
+                "metadata": {},
+            },
+        ]
+        result = export_user_logs_csv(logs, "testuser")
+        csv_text = result[3:].decode("utf-8")
+        reader = csv.DictReader(io.StringIO(csv_text))
+        rows = list(reader)
+        assert rows[0]["소스언어"] == ""
+        assert rows[0]["대상언어"] == ""
+
+    def test_csv_encoding_korean_text(self):
+        """한국어 텍스트가 올바르게 인코딩"""
+        logs = [
+            {
+                "id": 1,
+                "user_id": 10,
+                "action": "transcription",
+                "duration_seconds": 5,
+                "source_language": "ko",
+                "target_language": "en",
+                "created_at": "2026-04-28T10:00:00",
+                "metadata": {
+                    "source_text": "안녕하세요",
+                    "target_text": "Hello",
+                },
+            },
+        ]
+        result = export_user_logs_csv(logs, "testuser")
+        csv_text = result[3:].decode("utf-8")
+        assert "안녕하세요" in csv_text


### PR DESCRIPTION
## Summary
- Extract testable business logic from `admin.py` into pure functions in `admin_logic.py`: `validate_password`, `prepare_user_table_data`, `export_user_logs_csv`
- Add 28 unit tests in `tests/test_admin.py` covering password validation, user table data preparation, and CSV export
- CSV export tests verify UTF-8 BOM prefix, correct headers, Korean text encoding, and null metadata handling

## Test plan
- [x] `uv run pytest tests/test_admin.py -q` -- 28 tests pass
- [x] `uv run pytest -q -m 'not e2e'` -- 218 total tests pass (190 baseline + 28 new)
- [x] Password < 6 chars returns (False, error message)
- [x] Password mismatch returns (False, error message)
- [x] CSV output starts with BOM and has correct headers
- [x] User data preparation returns correct remaining_minutes calculations

Closes #14

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>