### PR TITLE
feat(test): add coverage threshold enforcement (ISSUE-18)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,9 +80,19 @@ known-first-party = ["realtime_en2ko_captions"]
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "-ra -m 'not e2e'"
+addopts = "-ra -m 'not e2e' --cov=. --cov-report=term-missing --cov-fail-under=50"
 testpaths = ["tests"]
 asyncio_mode = "auto"
 markers = [
     "e2e: End-to-end browser tests (requires Streamlit server)",
 ]
+
+[tool.coverage.run]
+omit = [
+    ".venv/*",
+    "tests/*",
+    "pages/*",
+]
+
+[tool.coverage.report]
+show_missing = true


### PR DESCRIPTION
## Summary
- Add `--cov=. --cov-report=term-missing --cov-fail-under=50` to pytest addopts in pyproject.toml
- Add `[tool.coverage.run]` with omit patterns for `.venv/*`, `tests/*`, `pages/*`
- `uv run pytest -q` now automatically shows coverage summary and enforces 50% minimum

## Test plan
- [x] `uv run pytest -q` shows coverage summary with per-file missing lines
- [x] Coverage meets 50% threshold (currently 52.48%)
- [x] All 207 existing tests pass

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>