### PR TITLE
feat(ws): add rate limiting to WebSocket handler (ISSUE-21)

### DIFF
--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,320 @@
+"""
+WebSocket rate limiting 단위 테스트
+_check_rate_limit 함수 및 handle_openai_websocket 통합 테스트
+"""
+
+import collections
+import json
+import sys
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# websocket_handler -> auth -> streamlit 의존성 mock
+if "streamlit" not in sys.modules:
+    sys.modules["streamlit"] = MagicMock()
+if "extra_streamlit_components" not in sys.modules:
+    sys.modules["extra_streamlit_components"] = MagicMock()
+
+
+# ============================================================
+# _check_rate_limit 단위 테스트
+# ============================================================
+class TestCheckRateLimit:
+    """_check_rate_limit 함수 테스트"""
+
+    def test_allows_messages_under_limit(self):
+        """제한 이하 메시지는 허용"""
+        from websocket_handler import _check_rate_limit
+
+        timestamps = collections.deque()
+        for _ in range(5):
+            assert _check_rate_limit(timestamps, limit=10) is True
+        assert len(timestamps) == 5
+
+    def test_blocks_messages_at_limit(self):
+        """제한에 도달하면 차단"""
+        from websocket_handler import _check_rate_limit
+
+        timestamps = collections.deque()
+        for _ in range(3):
+            assert _check_rate_limit(timestamps, limit=3) is True
+
+        # 4th message should be blocked
+        assert _check_rate_limit(timestamps, limit=3) is False
+
+    def test_old_timestamps_are_evicted(self):
+        """60초 이상 된 타임스탬프는 제거"""
+        from websocket_handler import _check_rate_limit
+
+        timestamps = collections.deque()
+        old_time = time.time() - 61.0
+        timestamps.append(old_time)
+        timestamps.append(old_time)
+        timestamps.append(old_time)
+
+        assert _check_rate_limit(timestamps, limit=3) is True
+        assert len(timestamps) == 1
+
+    def test_sliding_window_allows_after_expiry(self):
+        """슬라이딩 윈도우: 오래된 메시지 만료 후 새 메시지 허용"""
+        from websocket_handler import _check_rate_limit
+
+        timestamps = collections.deque()
+        now = time.time()
+
+        for _ in range(3):
+            timestamps.append(now - 59.0)
+
+        assert _check_rate_limit(timestamps, limit=3) is False
+
+        timestamps.clear()
+        for _ in range(3):
+            timestamps.append(now - 61.0)
+
+        assert _check_rate_limit(timestamps, limit=3) is True
+
+    def test_default_limit_uses_env_var(self):
+        """limit=None 시 WS_RATE_LIMIT_PER_MINUTE 사용"""
+        from websocket_handler import _check_rate_limit
+
+        timestamps = collections.deque()
+        with patch("websocket_handler.WS_RATE_LIMIT_PER_MINUTE", 2):
+            assert _check_rate_limit(timestamps) is True
+            assert _check_rate_limit(timestamps) is True
+            assert _check_rate_limit(timestamps) is False
+
+    def test_exactly_at_boundary(self):
+        """정확히 60초 경계의 타임스탬프 처리"""
+        from websocket_handler import _check_rate_limit
+
+        timestamps = collections.deque()
+        now = time.time()
+        timestamps.append(now - 60.0)
+
+        assert _check_rate_limit(timestamps, limit=1) is True
+        assert len(timestamps) == 1
+
+    def test_empty_deque_allows_message(self):
+        """빈 deque에서 첫 메시지 허용"""
+        from websocket_handler import _check_rate_limit
+
+        timestamps = collections.deque()
+        assert _check_rate_limit(timestamps, limit=1) is True
+        assert len(timestamps) == 1
+
+    def test_31st_message_in_60s_blocked(self):
+        """AC: 31st message in 60s is rate_limit_exceeded"""
+        from websocket_handler import _check_rate_limit
+
+        timestamps = collections.deque()
+        results = []
+        for _ in range(31):
+            results.append(_check_rate_limit(timestamps, limit=30))
+
+        # First 30 allowed, 31st blocked
+        assert all(results[:30])
+        assert results[30] is False
+
+
+# ============================================================
+# handle_openai_websocket 레이트 리밋 통합 테스트
+# ============================================================
+def _make_websocket(messages):
+    """테스트용 mock WebSocket (메시지 목록을 순서대로 반환)"""
+    ws = AsyncMock()
+    ws.send = AsyncMock()
+    ws.remote_address = ("127.0.0.1", 12345)
+
+    call_count = 0
+
+    async def mock_anext(self_ws):
+        nonlocal call_count
+        if call_count < len(messages):
+            msg = messages[call_count]
+            call_count += 1
+            return msg
+        raise StopAsyncIteration
+
+    ws.__aiter__ = lambda self_ws: self_ws
+    ws.__anext__ = mock_anext
+    return ws
+
+
+def _get_sent_messages(ws):
+    """WebSocket send 호출에서 JSON 메시지 추출"""
+    return [json.loads(call.args[0]) for call in ws.send.call_args_list]
+
+
+class TestHandleWebsocketRateLimit:
+    """handle_openai_websocket 내 rate limiting 통합 테스트"""
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_message_sends_error(self):
+        """레이트 리밋 초과 메시지에 error 응답, 번역 미수행"""
+        from websocket_handler import handle_openai_websocket
+
+        messages = [
+            json.dumps(
+                {
+                    "type": "transcript",
+                    "text": f"Hello {i}",
+                    "audio_duration_seconds": 1,
+                }
+            )
+            for i in range(4)
+        ]
+
+        ws = _make_websocket(messages)
+        mock_user = {
+            "id": 1,
+            "username": "testuser",
+            "role": "user",
+            "full_name": None,
+            "is_active": 1,
+        }
+        mock_handle_transcript = AsyncMock()
+
+        with (
+            patch(
+                "websocket_handler._authenticate_client",
+                new=AsyncMock(return_value=mock_user),
+            ),
+            patch(
+                "websocket_handler._init_translation_clients",
+                return_value=(MagicMock(), MagicMock(), True),
+            ),
+            patch(
+                "websocket_handler._handle_transcript",
+                mock_handle_transcript,
+            ),
+            patch("websocket_handler.WS_RATE_LIMIT_PER_MINUTE", 3),
+        ):
+            await handle_openai_websocket(ws)
+
+        # _handle_transcript called only 3 times (4th rate-limited)
+        assert mock_handle_transcript.call_count == 3
+
+        sent = _get_sent_messages(ws)
+        rate_limit_msgs = [m for m in sent if m.get("message") == "rate_limit_exceeded"]
+        assert len(rate_limit_msgs) == 1
+
+    @pytest.mark.asyncio
+    async def test_non_transcript_messages_bypass_rate_limit(self):
+        """transcript 이외 메시지는 레이트 리밋 미적용"""
+        from websocket_handler import handle_openai_websocket
+
+        messages = [json.dumps({"type": "request_openai_session"}) for _ in range(5)]
+
+        ws = _make_websocket(messages)
+        mock_user = {
+            "id": 1,
+            "username": "testuser",
+            "role": "user",
+            "full_name": None,
+            "is_active": 1,
+        }
+        mock_session_handler = AsyncMock()
+
+        with (
+            patch(
+                "websocket_handler._authenticate_client",
+                new=AsyncMock(return_value=mock_user),
+            ),
+            patch(
+                "websocket_handler._init_translation_clients",
+                return_value=(MagicMock(), MagicMock(), True),
+            ),
+            patch(
+                "websocket_handler._handle_session_request",
+                mock_session_handler,
+            ),
+            patch("websocket_handler.WS_RATE_LIMIT_PER_MINUTE", 3),
+        ):
+            await handle_openai_websocket(ws)
+
+        assert mock_session_handler.call_count == 5
+
+        sent = _get_sent_messages(ws)
+        rate_limit_msgs = [m for m in sent if m.get("message") == "rate_limit_exceeded"]
+        assert len(rate_limit_msgs) == 0
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_is_per_connection(self):
+        """각 연결은 독립적인 레이트 리밋을 가짐"""
+        from websocket_handler import handle_openai_websocket
+
+        mock_user = {
+            "id": 1,
+            "username": "testuser",
+            "role": "user",
+            "full_name": None,
+            "is_active": 1,
+        }
+
+        # Connection 1: send 3 messages (fills limit)
+        messages1 = [
+            json.dumps(
+                {
+                    "type": "transcript",
+                    "text": f"conn1-{i}",
+                    "audio_duration_seconds": 1,
+                }
+            )
+            for i in range(3)
+        ]
+        ws1 = _make_websocket(messages1)
+        mock_transcript1 = AsyncMock()
+
+        with (
+            patch(
+                "websocket_handler._authenticate_client",
+                new=AsyncMock(return_value=mock_user),
+            ),
+            patch(
+                "websocket_handler._init_translation_clients",
+                return_value=(MagicMock(), MagicMock(), True),
+            ),
+            patch(
+                "websocket_handler._handle_transcript",
+                mock_transcript1,
+            ),
+            patch("websocket_handler.WS_RATE_LIMIT_PER_MINUTE", 3),
+        ):
+            await handle_openai_websocket(ws1)
+
+        # Connection 2: should have fresh limit
+        messages2 = [
+            json.dumps(
+                {
+                    "type": "transcript",
+                    "text": f"conn2-{i}",
+                    "audio_duration_seconds": 1,
+                }
+            )
+            for i in range(3)
+        ]
+        ws2 = _make_websocket(messages2)
+        mock_transcript2 = AsyncMock()
+
+        with (
+            patch(
+                "websocket_handler._authenticate_client",
+                new=AsyncMock(return_value=mock_user),
+            ),
+            patch(
+                "websocket_handler._init_translation_clients",
+                return_value=(MagicMock(), MagicMock(), True),
+            ),
+            patch(
+                "websocket_handler._handle_transcript",
+                mock_transcript2,
+            ),
+            patch("websocket_handler.WS_RATE_LIMIT_PER_MINUTE", 3),
+        ):
+            await handle_openai_websocket(ws2)
+
+        # Both connections handled all 3 messages
+        assert mock_transcript1.call_count == 3
+        assert mock_transcript2.call_count == 3

--- a/websocket_handler.py
+++ b/websocket_handler.py
@@ -5,6 +5,7 @@ OpenAI Realtime API 통합, 번역 처리, 사용량 추적
 
 import asyncio
 import json
+import os
 import socket
 import time
 
@@ -20,6 +21,9 @@ from services import (
     get_aws_secret_access_key,
 )
 from translation import detect_language, translate_with_llm
+
+# Per-connection rate limit: max messages per minute (sliding window)
+WS_RATE_LIMIT_PER_MINUTE = int(os.getenv("WS_RATE_LIMIT_PER_MINUTE", "30"))
 
 
 def find_free_port(start_port=8765, max_port=8800):
@@ -365,11 +369,44 @@ async def _handle_transcript(
     )
 
 
+def _check_rate_limit(message_timestamps, limit=None):
+    """Sliding-window rate limit check for a single connection.
+
+    Args:
+        message_timestamps: collections.deque storing timestamps of recent messages.
+        limit: Max messages per 60s window.
+            Defaults to WS_RATE_LIMIT_PER_MINUTE.
+
+    Returns:
+        True if the message is allowed, False if rate limit exceeded.
+    """
+    if limit is None:
+        limit = WS_RATE_LIMIT_PER_MINUTE
+
+    now = time.time()
+    window_start = now - 60.0
+
+    # Evict timestamps older than the 60-second window
+    while message_timestamps and message_timestamps[0] <= window_start:
+        message_timestamps.popleft()
+
+    if len(message_timestamps) >= limit:
+        return False
+
+    message_timestamps.append(now)
+    return True
+
+
 async def handle_openai_websocket(websocket):
     """OpenAI Realtime API와 통합된 WebSocket 핸들러"""
+    import collections as _collections
+
     print(f"[WebSocket] OpenAI 모드 - 클라이언트 연결: {websocket.remote_address}")
 
     user_info = await _authenticate_client(websocket)
+
+    # Per-connection sliding window for rate limiting
+    message_timestamps = _collections.deque()
 
     try:
         (
@@ -393,6 +430,24 @@ async def handle_openai_websocket(websocket):
                 data = json.loads(message)
 
                 msg_type = data.get("type")
+
+                # Rate limit transcript messages
+                if msg_type == "transcript":
+                    if not _check_rate_limit(message_timestamps):
+                        await websocket.send(
+                            json.dumps(
+                                {
+                                    "type": "error",
+                                    "message": "rate_limit_exceeded",
+                                }
+                            )
+                        )
+                        print(
+                            "[RateLimit] Rate limit exceeded for "
+                            f"{websocket.remote_address}"
+                        )
+                        continue
+
                 if msg_type == "request_openai_session":
                     await _handle_session_request(websocket)
 


### PR DESCRIPTION
## Summary
- Add per-connection sliding-window rate limiter to `handle_openai_websocket`
- Default 30 messages/minute, configurable via `WS_RATE_LIMIT_PER_MINUTE` env var
- Rate-limited transcript messages receive `{"type": "error", "message": "rate_limit_exceeded"}`
- Non-transcript messages (e.g., session requests) bypass rate limiting
- Each connection has independent rate tracking via `collections.deque`

## Test plan
- [x] 8 unit tests for `_check_rate_limit` (boundary, eviction, default limit, 31st message)
- [x] 3 integration tests for `handle_openai_websocket` (rate-limited sends error, non-transcript bypass, per-connection independence)
- [x] All 218 tests pass, 80% coverage
- [x] Lint clean (ruff + black)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>