### PR TITLE
feat(ws): add language settings pass-through via WebSocket (ISSUE-2)

### DIFF
--- a/components/webrtc.html
+++ b/components/webrtc.html
@@ -1015,12 +1015,27 @@ try {
   // 설정 초기화
   loadSettings();
 
+  // 언어 변경을 WebSocket으로 전송 (ISSUE-2: 재연결 없이 반영)
+  function sendLanguageUpdate() {
+    if (openaiWebSocket && openaiWebSocket.readyState === WebSocket.OPEN) {
+      const inputLang = selInputLang ? selInputLang.value : 'auto';
+      const outputLang = selOutputLang ? selOutputLang.value : 'ko';
+      openaiWebSocket.send(JSON.stringify({
+        type: 'language_update',
+        input_lang: inputLang,
+        output_lang: outputLang
+      }));
+      console.log('[Lang] 언어 변경 전송:', inputLang, '->', outputLang);
+    }
+  }
+
   // 언어 선택 이벤트 핸들러
   if (selInputLang) {
     selInputLang.onchange = () => {
       localStorage.setItem('inputLanguage', selInputLang.value);
       checkLangWarning();
       updateWelcomeTranslationRules();
+      sendLanguageUpdate();
     };
   }
   if (selOutputLang) {
@@ -1028,6 +1043,7 @@ try {
       localStorage.setItem('outputLanguage', selOutputLang.value);
       checkLangWarning();
       updateWelcomeTranslationRules();
+      sendLanguageUpdate();
     };
   }
 
@@ -1703,13 +1719,20 @@ try {
       openaiWebSocket.onopen = () => {
         console.log(`✅ OpenAI WebSocket 연결됨: ${wsUrl}`);
 
-        // 사용자 정보 전송 (Bootstrap에서 전달받은 정보)
+        // 사용자 정보 + 언어 설정 전송 (ISSUE-2)
         if (BOOT.user_info) {
+          const inputLang = selInputLang ? selInputLang.value : 'auto';
+          const outputLang = selOutputLang ? selOutputLang.value : 'ko';
           openaiWebSocket.send(JSON.stringify({
             type: 'auth',
-            user: BOOT.user_info
+            user: BOOT.user_info,
+            language_settings: {
+              input_lang: inputLang,
+              output_lang: outputLang
+            }
           }));
-          console.log('[Auth] 사용자 정보 전송:', BOOT.user_info.username);
+          console.log('[Auth] 사용자 정보 전송:', BOOT.user_info.username,
+                       '언어:', inputLang, '->', outputLang);
         }
       };
 

--- a/tests/test_websocket_auth.py
+++ b/tests/test_websocket_auth.py
@@ -275,3 +275,86 @@ class TestAuthenticateClientDbValidation:
                 assert "testuser" not in msg.get("message", "")
                 # Should not contain user_id
                 assert str(db_user["id"]) not in msg.get("message", "")
+
+
+# === ISSUE-2: Language Settings in Auth ===
+
+
+class TestAuthenticateClientLanguageSettings:
+    """_authenticate_client 언어 설정 전달 테스트 (ISSUE-2)"""
+
+    def test_language_settings_extracted_from_auth(self, mock_db):
+        """auth 메시지에 language_settings가 있으면 validated_user에 포함"""
+        from websocket_handler import _authenticate_client
+
+        db_user = mock_db.get_user_by_username("testuser")
+        ws = _make_websocket(
+            {
+                "type": "auth",
+                "user": {
+                    "id": db_user["id"],
+                    "username": "testuser",
+                    "role": "user",
+                },
+                "language_settings": {
+                    "input_lang": "en",
+                    "output_lang": "ko",
+                },
+            }
+        )
+
+        with patch("websocket_handler.get_user_model", return_value=mock_db):
+            result = asyncio.run(_authenticate_client(ws))
+
+        assert result is not None
+        assert result["language_settings"]["input_lang"] == "en"
+        assert result["language_settings"]["output_lang"] == "ko"
+
+    def test_language_settings_defaults_when_missing(self, mock_db):
+        """auth 메시지에 language_settings가 없으면 기본값(auto/ko) 사용"""
+        from websocket_handler import _authenticate_client
+
+        db_user = mock_db.get_user_by_username("testuser")
+        ws = _make_websocket(
+            {
+                "type": "auth",
+                "user": {
+                    "id": db_user["id"],
+                    "username": "testuser",
+                    "role": "user",
+                },
+            }
+        )
+
+        with patch("websocket_handler.get_user_model", return_value=mock_db):
+            result = asyncio.run(_authenticate_client(ws))
+
+        assert result is not None
+        assert result["language_settings"]["input_lang"] == "auto"
+        assert result["language_settings"]["output_lang"] == "ko"
+
+    def test_language_settings_partial_defaults(self, mock_db):
+        """language_settings에 일부 필드만 있으면 나머지는 기본값"""
+        from websocket_handler import _authenticate_client
+
+        db_user = mock_db.get_user_by_username("testuser")
+        ws = _make_websocket(
+            {
+                "type": "auth",
+                "user": {
+                    "id": db_user["id"],
+                    "username": "testuser",
+                    "role": "user",
+                },
+                "language_settings": {
+                    "input_lang": "ja",
+                },
+            }
+        )
+
+        with patch("websocket_handler.get_user_model", return_value=mock_db):
+            result = asyncio.run(_authenticate_client(ws))
+
+        assert result is not None
+        assert result["language_settings"]["input_lang"] == "ja"
+        assert result["language_settings"]["output_lang"] == "ko"

--- a/tests/test_websocket_handler.py
+++ b/tests/test_websocket_handler.py
@@ -437,3 +437,226 @@ class TestHandleOpenaiWebsocket:
         error_msgs = [m for m in sent if m.get("type") == "error"]
         assert len(error_msgs) >= 1
         assert "Invalid JSON" in error_msgs[0]["message"]
+
+
+# ============================================================
+# ISSUE-2: Language settings in _handle_transcript
+# ============================================================
+class TestHandleTranscriptLanguageSettings:
+    """_handle_transcript 언어 설정 전달 테스트 (ISSUE-2)"""
+
+    def test_specific_language_skips_detect(self, mock_db, user_info):
+        """input_lang이 특정 언어이면 detect_language를 호출하지 않음"""
+        from database import UsageLog, User
+        from websocket_handler import _handle_transcript
+
+        user_model = User(mock_db)
+        usage_log_model = UsageLog(mock_db)
+
+        ws = _make_websocket()
+        data = {"text": "Hello world", "audio_duration_seconds": 5}
+        lang_settings = {"input_lang": "en", "output_lang": "ja"}
+
+        with (
+            patch("websocket_handler.check_usage_limit", return_value=True),
+            patch("websocket_handler.detect_language") as mock_detect,
+            patch(
+                "websocket_handler._translate_text",
+                return_value=("こんにちは", True),
+            ),
+            patch("websocket_handler.get_user_model", return_value=user_model),
+            patch(
+                "websocket_handler.get_usage_log_model",
+                return_value=usage_log_model,
+            ),
+            patch("websocket_handler.update_user_session"),
+        ):
+            asyncio.run(
+                _handle_transcript(
+                    ws,
+                    data,
+                    user_info,
+                    MagicMock(),
+                    MagicMock(),
+                    True,
+                    language_settings=lang_settings,
+                )
+            )
+
+        # detect_language should NOT be called
+        mock_detect.assert_not_called()
+
+        sent = _get_sent_messages(ws)
+        assert len(sent) == 1
+        assert sent[0]["source_language"] == "en"
+        assert sent[0]["target_language"] == "ja"
+
+    def test_auto_input_lang_uses_detect(self, mock_db, user_info):
+        """input_lang이 'auto'이면 detect_language()를 사용"""
+        from database import UsageLog, User
+        from websocket_handler import _handle_transcript
+
+        user_model = User(mock_db)
+        usage_log_model = UsageLog(mock_db)
+
+        ws = _make_websocket()
+        data = {"text": "Hello world", "audio_duration_seconds": 5}
+        lang_settings = {"input_lang": "auto", "output_lang": "ko"}
+
+        with (
+            patch("websocket_handler.check_usage_limit", return_value=True),
+            patch(
+                "websocket_handler.detect_language",
+                return_value=("en", "ko"),
+            ) as mock_detect,
+            patch(
+                "websocket_handler._translate_text",
+                return_value=("안녕하세요", True),
+            ),
+            patch("websocket_handler.get_user_model", return_value=user_model),
+            patch(
+                "websocket_handler.get_usage_log_model",
+                return_value=usage_log_model,
+            ),
+            patch("websocket_handler.update_user_session"),
+        ):
+            asyncio.run(
+                _handle_transcript(
+                    ws,
+                    data,
+                    user_info,
+                    MagicMock(),
+                    MagicMock(),
+                    True,
+                    language_settings=lang_settings,
+                )
+            )
+
+        # detect_language SHOULD be called
+        mock_detect.assert_called_once_with("Hello world")
+
+    def test_no_language_settings_uses_detect(self, mock_db, user_info):
+        """language_settings가 None이면 detect_language() 사용 (하위 호환)"""
+        from database import UsageLog, User
+        from websocket_handler import _handle_transcript
+
+        user_model = User(mock_db)
+        usage_log_model = UsageLog(mock_db)
+
+        ws = _make_websocket()
+        data = {"text": "Hello world", "audio_duration_seconds": 5}
+
+        with (
+            patch("websocket_handler.check_usage_limit", return_value=True),
+            patch(
+                "websocket_handler.detect_language",
+                return_value=("en", "ko"),
+            ) as mock_detect,
+            patch(
+                "websocket_handler._translate_text",
+                return_value=("안녕하세요", True),
+            ),
+            patch("websocket_handler.get_user_model", return_value=user_model),
+            patch(
+                "websocket_handler.get_usage_log_model",
+                return_value=usage_log_model,
+            ),
+            patch("websocket_handler.update_user_session"),
+        ):
+            asyncio.run(
+                _handle_transcript(
+                    ws,
+                    data,
+                    user_info,
+                    MagicMock(),
+                    MagicMock(),
+                    True,
+                    language_settings=None,
+                )
+            )
+
+        mock_detect.assert_called_once_with("Hello world")
+
+    def test_empty_input_lang_uses_detect(self, mock_db, user_info):
+        """input_lang이 빈 문자열이면 detect_language() 사용"""
+        from database import UsageLog, User
+        from websocket_handler import _handle_transcript
+
+        user_model = User(mock_db)
+        usage_log_model = UsageLog(mock_db)
+
+        ws = _make_websocket()
+        data = {"text": "Hello", "audio_duration_seconds": 3}
+        lang_settings = {"input_lang": "", "output_lang": "ko"}
+
+        with (
+            patch("websocket_handler.check_usage_limit", return_value=True),
+            patch(
+                "websocket_handler.detect_language",
+                return_value=("en", "ko"),
+            ) as mock_detect,
+            patch(
+                "websocket_handler._translate_text",
+                return_value=("안녕", True),
+            ),
+            patch("websocket_handler.get_user_model", return_value=user_model),
+            patch(
+                "websocket_handler.get_usage_log_model",
+                return_value=usage_log_model,
+            ),
+            patch("websocket_handler.update_user_session"),
+        ):
+            asyncio.run(
+                _handle_transcript(
+                    ws,
+                    data,
+                    user_info,
+                    MagicMock(),
+                    MagicMock(),
+                    True,
+                    language_settings=lang_settings,
+                )
+            )
+
+        mock_detect.assert_called_once()
+
+    def test_specific_lang_defaults_output_to_ko(self, mock_db, user_info):
+        """output_lang이 없으면 기본값 'ko' 사용"""
+        from database import UsageLog, User
+        from websocket_handler import _handle_transcript
+
+        user_model = User(mock_db)
+        usage_log_model = UsageLog(mock_db)
+
+        ws = _make_websocket()
+        data = {"text": "Bonjour", "audio_duration_seconds": 3}
+        lang_settings = {"input_lang": "fr"}
+
+        with (
+            patch("websocket_handler.check_usage_limit", return_value=True),
+            patch(
+                "websocket_handler._translate_text",
+                return_value=("안녕하세요", False),
+            ),
+            patch("websocket_handler.get_user_model", return_value=user_model),
+            patch(
+                "websocket_handler.get_usage_log_model",
+                return_value=usage_log_model,
+            ),
+            patch("websocket_handler.update_user_session"),
+        ):
+            asyncio.run(
+                _handle_transcript(
+                    ws,
+                    data,
+                    user_info,
+                    MagicMock(),
+                    MagicMock(),
+                    True,
+                    language_settings=lang_settings,
+                )
+            )
+
+        sent = _get_sent_messages(ws)
+        assert sent[0]["source_language"] == "fr"
+        assert sent[0]["target_language"] == "ko"

--- a/websocket_handler.py
+++ b/websocket_handler.py
@@ -120,6 +120,13 @@ async def _authenticate_client(websocket):
                 "is_active": db_user["is_active"],
             }
 
+            # Extract language settings from auth message (ISSUE-2)
+            language_settings = data.get("language_settings", {})
+            validated_user["language_settings"] = {
+                "input_lang": language_settings.get("input_lang", "auto"),
+                "output_lang": language_settings.get("output_lang", "ko"),
+            }
+
             print(f"[Auth] 사용자 인증 성공: {validated_user['username']}")
             await websocket.send(
                 json.dumps({"type": "auth_success", "message": "인증 완료"})
@@ -280,6 +287,7 @@ async def _handle_transcript(
     translate_client,
     bedrock_client,
     bedrock_available,
+    language_settings=None,
 ):
     """트랜스크립트 메시지 처리 (번역 + 사용량)"""
     transcript = data.get("text", "")
@@ -326,7 +334,17 @@ async def _handle_transcript(
         )
         return
 
-    source_lang, target_lang = detect_language(transcript)
+    # Use connection-level language settings if available (ISSUE-2)
+    lang = language_settings or {}
+    input_lang = lang.get("input_lang", "auto")
+    output_lang = lang.get("output_lang")
+
+    if input_lang == "auto" or not input_lang:
+        # Fall back to auto-detection
+        source_lang, target_lang = detect_language(transcript)
+    else:
+        source_lang = input_lang
+        target_lang = output_lang or "ko"
 
     translated_text, used_llm = _translate_text(
         transcript,
@@ -405,6 +423,14 @@ async def handle_openai_websocket(websocket):
 
     user_info = await _authenticate_client(websocket)
 
+    # Per-connection language settings (ISSUE-2)
+    # Initialised from auth message; updated by language_update messages.
+    language_settings = (
+        user_info.get("language_settings", {"input_lang": "auto", "output_lang": "ko"})
+        if user_info
+        else {"input_lang": "auto", "output_lang": "ko"}
+    )
+
     # Per-connection sliding window for rate limiting
     message_timestamps = _collections.deque()
 
@@ -451,6 +477,31 @@ async def handle_openai_websocket(websocket):
                 if msg_type == "request_openai_session":
                     await _handle_session_request(websocket)
 
+                elif msg_type == "language_update":
+                    # Live language change without reconnection (ISSUE-2)
+                    language_settings["input_lang"] = data.get(
+                        "input_lang",
+                        language_settings["input_lang"],
+                    )
+                    language_settings["output_lang"] = data.get(
+                        "output_lang",
+                        language_settings["output_lang"],
+                    )
+                    await websocket.send(
+                        json.dumps(
+                            {
+                                "type": "language_updated",
+                                "input_lang": language_settings["input_lang"],
+                                "output_lang": language_settings["output_lang"],
+                            }
+                        )
+                    )
+                    print(
+                        f"[Lang] Language updated: "
+                        f"{language_settings['input_lang']} -> "
+                        f"{language_settings['output_lang']}"
+                    )
+
                 elif msg_type == "transcript":
                     await _handle_transcript(
                         websocket,
@@ -459,6 +510,7 @@ async def handle_openai_websocket(websocket):
                         translate_client,
                         bedrock_client,
                         bedrock_available,
+                        language_settings=language_settings,
                     )
 
             except json.JSONDecodeError:


### PR DESCRIPTION
## Summary
- Browser sends selected input/output language to server via WebSocket auth message (`language_settings` field)
- Live language changes sent via `language_update` message type -- no reconnection needed
- Server uses connection-level language settings for translation; falls back to `detect_language()` when input is "auto"
- 8 new tests covering all language routing paths

Closes #14

## Test plan
- [x] `uv run pytest -q -m 'not e2e'` -- 238 passed, 80% coverage
- [ ] Manual: change language dropdown while connected, verify translation uses new language pair
- [ ] Manual: set input to "auto", verify detect_language() is used
- [ ] Manual: set input to specific language (e.g., "en"), verify source is fixed

Generated with [Claude Code](https://claude.com/claude-code)