### PR TITLE
feat(translation): expand auto-detect to Chinese/Vietnamese (ISSUE-4)

### DIFF
--- a/tests/test_detect_language.py
+++ b/tests/test_detect_language.py
@@ -1,0 +1,171 @@
+"""
+다국어 감지 기능 단위 테스트 (ISSUE-4)
+detect_language()의 한국어/중국어/베트남어/영어 감지 및
+output_lang 폴백 로직 검증
+"""
+
+from translation import detect_language
+
+
+class TestDetectLanguageKorean:
+    """한국어 감지 테스트"""
+
+    def test_korean_text_detected(self):
+        """한국어 텍스트는 'ko'로 감지"""
+        source, target = detect_language("안녕하세요")
+        assert source == "ko"
+
+    def test_korean_default_output_ko_fallback(self):
+        """output_lang='ko'이고 detected='ko'이면 target='en' 폴백"""
+        source, target = detect_language("안녕하세요", output_lang="ko")
+        assert source == "ko"
+        assert target == "en"
+
+    def test_korean_output_en(self):
+        """output_lang='en'이면 target='en'"""
+        source, target = detect_language("안녕하세요", output_lang="en")
+        assert source == "ko"
+        assert target == "en"
+
+    def test_korean_output_zh(self):
+        """output_lang='zh'이면 target='zh'"""
+        source, target = detect_language("안녕하세요", output_lang="zh")
+        assert source == "ko"
+        assert target == "zh"
+
+    def test_korean_output_vi(self):
+        """output_lang='vi'이면 target='vi'"""
+        source, target = detect_language("안녕하세요", output_lang="vi")
+        assert source == "ko"
+        assert target == "vi"
+
+
+class TestDetectLanguageChinese:
+    """중국어 감지 테스트"""
+
+    def test_chinese_text_detected(self):
+        """중국어 텍스트는 'zh'로 감지"""
+        source, target = detect_language("你好世界")
+        assert source == "zh"
+
+    def test_chinese_default_output_ko(self):
+        """output_lang='ko'이면 target='ko'"""
+        source, target = detect_language("你好世界", output_lang="ko")
+        assert source == "zh"
+        assert target == "ko"
+
+    def test_chinese_output_zh_fallback(self):
+        """output_lang='zh'이고 detected='zh'이면 target='en' 폴백"""
+        source, target = detect_language("你好世界", output_lang="zh")
+        assert source == "zh"
+        assert target == "en"
+
+    def test_chinese_output_en(self):
+        """output_lang='en'이면 target='en'"""
+        source, target = detect_language("你好世界", output_lang="en")
+        assert source == "zh"
+        assert target == "en"
+
+    def test_chinese_output_vi(self):
+        """output_lang='vi'이면 target='vi'"""
+        source, target = detect_language("你好世界", output_lang="vi")
+        assert source == "zh"
+        assert target == "vi"
+
+
+class TestDetectLanguageVietnamese:
+    """베트남어 감지 테스트"""
+
+    def test_vietnamese_text_detected(self):
+        """베트남어 특수 문자가 있으면 'vi'로 감지"""
+        source, target = detect_language("Xin chào các bạn ơ")
+        assert source == "vi"
+
+    def test_vietnamese_special_chars(self):
+        """다양한 베트남어 특수 문자 감지"""
+        # Test with ư (common Vietnamese char)
+        source, _ = detect_language("Tôi là người Việt Nam ư")
+        assert source == "vi"
+
+    def test_vietnamese_default_output_ko(self):
+        """output_lang='ko'이면 target='ko'"""
+        source, target = detect_language("xin chào ơ", output_lang="ko")
+        assert source == "vi"
+        assert target == "ko"
+
+    def test_vietnamese_output_vi_fallback(self):
+        """output_lang='vi'이고 detected='vi'이면 target='en' 폴백"""
+        source, target = detect_language("xin chào ơ", output_lang="vi")
+        assert source == "vi"
+        assert target == "en"
+
+    def test_vietnamese_output_en(self):
+        """output_lang='en'이면 target='en'"""
+        source, target = detect_language("xin chào ơ", output_lang="en")
+        assert source == "vi"
+        assert target == "en"
+
+    def test_vietnamese_output_zh(self):
+        """output_lang='zh'이면 target='zh'"""
+        source, target = detect_language("xin chào ơ", output_lang="zh")
+        assert source == "vi"
+        assert target == "zh"
+
+
+class TestDetectLanguageEnglish:
+    """영어(기본) 감지 테스트"""
+
+    def test_english_text_detected(self):
+        """영어 텍스트는 'en'으로 감지"""
+        source, target = detect_language("Hello world")
+        assert source == "en"
+
+    def test_english_default_output_ko(self):
+        """output_lang='ko'이면 target='ko'"""
+        source, target = detect_language("Hello world", output_lang="ko")
+        assert source == "en"
+        assert target == "ko"
+
+    def test_english_output_en_fallback(self):
+        """output_lang='en'이고 detected='en'이면 target='ko' 폴백"""
+        source, target = detect_language("Hello world", output_lang="en")
+        assert source == "en"
+        assert target == "ko"
+
+    def test_english_output_zh(self):
+        """output_lang='zh'이면 target='zh'"""
+        source, target = detect_language("Hello world", output_lang="zh")
+        assert source == "en"
+        assert target == "zh"
+
+    def test_english_output_vi(self):
+        """output_lang='vi'이면 target='vi'"""
+        source, target = detect_language("Hello world", output_lang="vi")
+        assert source == "en"
+        assert target == "vi"
+
+
+class TestDetectLanguagePriority:
+    """감지 우선순위 테스트"""
+
+    def test_korean_priority_over_chinese(self):
+        """한국어가 중국어보다 우선 감지"""
+        # Text with both Korean and Chinese characters
+        source, _ = detect_language("안녕你好")
+        assert source == "ko"
+
+    def test_chinese_priority_over_vietnamese(self):
+        """중국어가 베트남어보다 우선 감지 (한국어 없을 때)"""
+        # CJK chars take priority over Vietnamese diacritics
+        source, _ = detect_language("你好 ơ")
+        assert source == "zh"
+
+    def test_backward_compatibility_no_output_lang(self):
+        """output_lang 미지정 시 기본값 'ko' 유지"""
+        source, target = detect_language("Hello world")
+        assert source == "en"
+        assert target == "ko"
+
+        source, target = detect_language("안녕하세요")
+        assert source == "ko"
+        assert target == "en"

--- a/tests/test_websocket_handler.py
+++ b/tests/test_websocket_handler.py
@@ -532,8 +532,8 @@ class TestHandleTranscriptLanguageSettings:
                 )
             )
 
-        # detect_language SHOULD be called
-        mock_detect.assert_called_once_with("Hello world")
+        # detect_language SHOULD be called with output_lang (ISSUE-4)
+        mock_detect.assert_called_once_with("Hello world", output_lang="ko")
 
     def test_no_language_settings_uses_detect(self, mock_db, user_info):
         """language_settings가 None이면 detect_language() 사용 (하위 호환)"""
@@ -575,7 +575,7 @@ class TestHandleTranscriptLanguageSettings:
                 )
             )
 
-        mock_detect.assert_called_once_with("Hello world")
+        mock_detect.assert_called_once_with("Hello world", output_lang="ko")
 
     def test_empty_input_lang_uses_detect(self, mock_db, user_info):
         """input_lang이 빈 문자열이면 detect_language() 사용"""

--- a/translation.py
+++ b/translation.py
@@ -26,12 +26,49 @@ BEDROCK_MODEL_IDS = [
 ]
 
 
-def detect_language(text):
-    """간단한 한국어 감지 (한글 유니코드 범위 기반)"""
+def detect_language(text, output_lang="ko"):
+    """다국어 감지 (유니코드 범위 기반)
+
+    감지 우선순위: 한국어 > 중국어 > 베트남어 > 영어(기본)
+    detected == output_lang이면 source를 "en"으로 폴백.
+
+    Args:
+        text: 감지 대상 텍스트
+        output_lang: 출력 언어 (detected와 같으면 폴백)
+
+    Returns:
+        (source_lang, target_lang) 튜플
+    """
+    # 1. Korean: hangul range
     has_korean = any(0xAC00 <= ord(c) <= 0xD7A3 for c in text)
     if has_korean:
-        return "ko", "en"
-    return "en", "ko"
+        detected = "ko"
+        if detected == output_lang:
+            return "ko", "en"
+        return "ko", output_lang
+
+    # 2. Chinese: CJK unified ideographs
+    has_chinese = any(0x4E00 <= ord(c) <= 0x9FFF for c in text)
+    if has_chinese:
+        detected = "zh"
+        if detected == output_lang:
+            return "zh", "en"
+        return "zh", output_lang
+
+    # 3. Vietnamese: special diacritics
+    vietnamese_chars = set("ăơưđĂƠƯĐ")
+    has_vietnamese = any(c in vietnamese_chars for c in text)
+    if has_vietnamese:
+        detected = "vi"
+        if detected == output_lang:
+            return "vi", "en"
+        return "vi", output_lang
+
+    # 4. Default: English
+    detected = "en"
+    if detected == output_lang:
+        return "en", "ko"
+    return "en", output_lang
 
 
 def split_into_sentences(text, language="ko"):

--- a/websocket_handler.py
+++ b/websocket_handler.py
@@ -340,8 +340,10 @@ async def _handle_transcript(
     output_lang = lang.get("output_lang")
 
     if input_lang == "auto" or not input_lang:
-        # Fall back to auto-detection
-        source_lang, target_lang = detect_language(transcript)
+        # Fall back to auto-detection (ISSUE-4)
+        source_lang, target_lang = detect_language(
+            transcript, output_lang=output_lang or "ko"
+        )
     else:
         source_lang = input_lang
         target_lang = output_lang or "ko"


### PR DESCRIPTION
## Summary
- Expanded `detect_language()` to detect Chinese (CJK unified ideographs `0x4E00-0x9FFF`) and Vietnamese (special diacritics `ă, ơ, ư, đ`)
- Detection priority: Korean > Chinese > Vietnamese > English (default)
- Added `output_lang` parameter: if detected language == output language, gracefully falls back to "en" as source
- Updated `_handle_transcript` in websocket_handler.py to pass `output_lang` to `detect_language` in auto-detect mode
- Updated existing ISSUE-2 tests for new call signature
- Added 24 unit tests covering all detection paths, fallback logic, and priority ordering

Closes #16

## Test plan
- [x] `uv run pytest -q -m 'not e2e'` -- 300 tests pass (24 new), 81% coverage
- [x] Korean, Chinese, Vietnamese, English text correctly detected
- [x] `detected == output_lang` fallback logic verified
- [x] Backward compatibility: existing callers without `output_lang` work unchanged
- [x] Ruff lint clean

Generated with [Claude Code](https://claude.com/claude-code)