### PR TITLE
[ISSUE-36] webrtc.html 뷰포트 반응형 높이 적용

### DIFF
--- a/components/scroll_lock.html
+++ b/components/scroll_lock.html
@@ -44,6 +44,7 @@
     .main iframe {
         width: 100% !important;
         height: 100vh !important;
+        height: 100dvh !important;
         border: none !important;
         margin: 0 !important;
         padding: 0 !important;

--- a/components/scroll_lock.html
+++ b/components/scroll_lock.html
@@ -43,6 +43,7 @@
     /* iframe을 전체 화면에 정확히 맞춤 */
     .main iframe {
         width: 100% !important;
+        height: 100vh !important;
         border: none !important;
         margin: 0 !important;
         padding: 0 !important;

--- a/components/webrtc.html
+++ b/components/webrtc.html
@@ -16,8 +16,8 @@
       background: linear-gradient(135deg, #0f0f23 0%, #1a1a2e 50%, #16213e 100%);
       color: #ffffff;
       overflow: hidden !important;
-      height: 90vh !important;
-      max-height: 90vh !important;
+      height: 100% !important;
+      max-height: 100% !important;
       box-sizing: border-box;
       position: relative;
     }
@@ -621,8 +621,8 @@
     @media (max-width: 768px) {
       body {
         padding: 5px;
-        height: 90vh !important;
-        max-height: 90vh !important;
+        height: 100% !important;
+        max-height: 100% !important;
       }
 
       .settings-panel {
@@ -683,8 +683,8 @@
     @media (max-height: 600px) {
       body {
         padding: 5px;
-        height: 90vh !important;
-        max-height: 90vh !important;
+        height: 100% !important;
+        max-height: 100% !important;
       }
 
       .caption-container {

--- a/docs/review_lessons.md
+++ b/docs/review_lessons.md
@@ -93,3 +93,12 @@ Preventable patterns identified during code reviews. Each entry includes when th
 - **Description**: Icon-only buttons (emoji/unicode symbols) shipped without `aria-label` attributes, and `border: none` removed default focus rings without providing `:focus-visible` replacements. Font controls had `opacity: 0.15` making them effectively invisible (contrast ratio 1.39:1 vs required 4.5:1). These are WCAG 2.1 AA failures that affect keyboard and screen reader users.
 - **Prevention**: At implementation time, every interactive element should have: (1) an accessible name (`aria-label` for icon-only buttons), (2) a visible focus indicator, (3) sufficient contrast in its default state. Add these as a checklist item for UI PRs.
 - **Recommended action**: Create a project-level a11y checklist for UI components: aria-labels, focus-visible styles, contrast ratios, touch target sizes (44x44px minimum).
+
+## [RL-011] Using `100vh` without `dvh` fallback for mobile Safari
+
+- **Category**: Code Quality
+- **Frequency**: 1
+- **Observed-In**: PR #57 (ISSUE-36)
+- **Description**: CSS `100vh` on iOS Safari includes the space behind the browser's address bar, so elements sized to `100vh` extend beyond the visible viewport when the address bar is shown. This is a well-documented browser inconsistency affecting all iOS Safari versions. The fix is to use `100dvh` (dynamic viewport height, supported since Safari 15.4 / iOS 15.4, March 2022) with `100vh` as a fallback for older browsers.
+- **Prevention**: At implementation time, whenever `100vh` is used for full-viewport sizing, also declare `100dvh` as a progressive enhancement on the next line. The property cascade means older browsers ignore the unknown `dvh` unit and use the `vh` fallback.
+- **Recommended action**: Establish a project CSS convention: always pair `height: 100vh` with `height: 100dvh` when the intent is to fill the visible viewport. Apply retroactively to `scroll_lock.html` which uses `100vh` in multiple rules.

--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -1,24 +1,22 @@
-# Review Notes -- PR #42 (testgen/add-missing-tests)
+# Review Notes -- PR #57 (ISSUE-36: webrtc.html viewport responsive height)
 
 **Reviewer**: Claude Opus 4.6 (automated)
-**Date**: 2026-04-28
-**PR Size**: 298 lines, 1 file (`tests/test_coverage_gaps.py`), 11 tests
-**Test Results**: 11/11 passing
-**Confidence Rating**: High -- all source files, existing test patterns, and the new test file were reviewed in full.
+**Date**: 2026-05-06
+**PR Size**: +105 -6 lines across 3 files (2 HTML, 1 test)
+**Test Results**: 9/9 passing
+**Confidence Rating**: High -- all changed files, existing layout files, and the full issue AC were reviewed.
 
 ---
 
 ## Summary
 
-PR #42 adds `tests/test_coverage_gaps.py` covering previously untested code paths:
-- `websocket_handler._init_translation_clients` (happy path + Bedrock fallback)
-- `websocket_handler._handle_session_request` (success + failure)
-- `websocket_handler.handle_openai_websocket` language_update message branch
-- `websocket_handler._authenticate_client` generic exception branch
-- `auth.init_session_state` (3 scenarios)
-- `auth.get_user_remaining_seconds` (no user + logged-in user)
+PR #57 fixes the viewport-height mismatch in the caption iframe. Previously, the iframe was fixed at 900px (via `st.components.v1.html(height=900)`) and the body used `90vh` (= 810px of 900px), ignoring the actual browser viewport. This PR:
 
-All 11 tests pass. The tests are generally well-structured with meaningful assertions. However, there are style conformance issues and one test isolation bug that should be addressed before merge.
+1. Adds `height: 100vh !important` to `.main iframe` in `scroll_lock.html` (overrides inline 900px)
+2. Changes `body` height from `90vh` to `100%` in `webrtc.html` (3 occurrences: main rule + 2 media queries)
+3. Adds 9 regression tests validating the CSS changes
+
+The approach is sound: the parent page's `scroll_lock.html` (where `vh` refers to the browser viewport) sets the iframe to `100vh`, and the iframe content uses `100%` (which correctly resolves to the iframe's dimensions rather than defining its own viewport unit).
 
 ---
 
@@ -26,68 +24,87 @@ All 11 tests pass. The tests are generally well-structured with meaningful asser
 
 ### Code Review
 
-### [Medium] CR-1: Module-level sys.modules mutation lacks per-test cleanup (test isolation risk)
+### [Info] CR-1: Body `margin-top: 5%` causes slight overflow with `height: 100%`
 
-- **File**: `tests/test_coverage_gaps.py:35-41`
-- **Issue**: The file mutates `sys.modules` at import time (lines 35-41) and never cleans up. This is the older pattern used in `test_websocket_handler.py`, but the established best practice in this project (see `test_auth_module.py:32-47`) uses a `monkeypatch`-based `autouse` fixture that: (a) replaces `sys.modules` entries per test, (b) pops the `auth` module to force reimport, ensuring clean state. Without this, the `auth` module caches a reference to the first mock `st` object, and mutations to `auth.st.session_state` in one test leak into subsequent tests. This is particularly dangerous for the `TestInitSessionState` class, where three tests sequentially mutate `auth.st.session_state`.
-- **Blocking**: Yes -- test ordering could produce false passes or false failures.
-- **Fix**: Adopt the `monkeypatch` autouse fixture pattern from `test_auth_module.py` for the auth-related test classes (`TestInitSessionState`, `TestGetUserRemainingSeconds`). The websocket-related tests (which only patch at the function level) are less affected but would still benefit from consistency.
+- **File**: `components/webrtc.html:13` (`margin: 5% 0 0 0`)
+- **Issue**: The body has `height: 100%` and `margin-top: 5%`, so the total space occupied is 105% of the containing block. The `overflow: hidden !important` on body clips the overflow, so content is not visibly broken. However, the effective visible area for body content is 95% of the viewport, not 100%. This was the same behavior before the change (90vh + 5% margin = also overflow), so this is not a regression.
+- **Blocking**: No. Pre-existing behavior, not introduced by this PR.
+- **Suggestion**: Consider using `padding-top` instead of `margin-top` (which stays inside the content box) or adjusting height to `calc(100% - 5%)` in a follow-up.
 
-### [Medium] CR-2: SessionState class duplicated across test files (RL-001 pattern)
+### [Medium] CR-2: Mobile Safari `100vh` includes address bar, causing content clipping
 
-- **File**: `tests/test_coverage_gaps.py:16-33`
-- **Issue**: The `SessionState` helper class is copy-pasted from `tests/test_auth_module.py:12-29`. This is the exact pattern described in RL-001 (copy-paste testing). If the real Streamlit `session_state` behavior changes or a bug is found in the helper, both copies must be updated.
-- **Blocking**: No -- functional correctness is not affected.
-- **Fix**: Extract `SessionState` into `tests/conftest.py` or a shared `tests/helpers.py` module and import from both test files. This is a follow-up task.
+- **File**: `components/scroll_lock.html:46` (`height: 100vh !important`)
+- **Issue**: On iOS Safari, `100vh` includes the space behind the browser's address/navigation bar. When the address bar is visible (e.g., after page load, before scrolling), `100vh` is taller than the visible viewport, causing the bottom ~70-90px of the iframe to be hidden behind the browser chrome. This is the well-known "iOS 100vh bug." The fix is to use `100dvh` (dynamic viewport height, supported since iOS 15.4 / Safari 15.4, 2022) with a `100vh` fallback.
+- **Blocking**: No -- the target browsers listed in CLAUDE.md are "Chrome/Edge/Safari latest," and this is an improvement over the previous fixed-900px approach even on mobile Safari. However, this is a meaningful UX issue for mobile users.
+- **Suggested fix** (follow-up):
+  ```css
+  .main iframe {
+      height: 100vh !important;  /* fallback */
+      height: 100dvh !important; /* modern browsers */
+  }
+  ```
+  Apply the same pattern to all `100vh` usages in `scroll_lock.html`.
 
-### [Low] CR-3: TestLanguageUpdateMessage verifies echo response but not internal state mutation
+### [Low] CR-3: Test regex patterns are fragile against whitespace/formatting changes
 
-- **File**: `tests/test_coverage_gaps.py:153-200`
-- **Issue**: The test verifies that a `language_updated` response message is sent with the correct `input_lang` and `output_lang`. However, the primary purpose of the `language_update` handler (lines 482-505 of `websocket_handler.py`) is to mutate the connection-level `language_settings` dict so that subsequent `transcript` messages use the new settings. The test does not verify this side effect -- it only checks the echo. If the echo line were present but the dict mutation were removed, the test would still pass.
-- **Mitigating factors**: The echo values are derived from the same `language_settings` dict that was mutated, so in practice they are correlated. The risk of the mutation being removed while the echo remains is low.
-- **Fix suggestion**: Send a follow-up `transcript` message after the `language_update` and verify the translation uses the new language settings. This would be a more robust integration test.
-
-### [Low] CR-4: Missing `pytest` import deviates from project convention
-
-- **File**: `tests/test_coverage_gaps.py`
-- **Issue**: The file does not import `pytest` and uses no pytest fixtures, markers, or parametrize decorators. Every other test file in the project imports `pytest`. While the tests work fine without it (plain `unittest.mock` + class-based tests), the lack of fixtures means no shared setup/teardown, which contributes to CR-1.
+- **File**: `tests/test_viewport_responsive.py:55-56, 63-64`
+- **Issue**: The media query tests use `\n\s*\n` as the end delimiter for the media query block. If someone reformats the CSS (e.g., removes the blank line between rules, or a minifier strips whitespace), the regex will fail to match and the test will error with "media query not found" rather than testing the actual content. The `_get_body_css()` helper uses `[^}]*}` which is more robust.
+- **Mitigating factors**: These are static HTML files unlikely to be minified, and the error messages are descriptive enough to debug.
 - **Blocking**: No.
-- **Fix**: Add `import pytest` and consider converting the auth-related tests to use fixtures for session state setup.
+- **Suggestion**: Use a more robust end delimiter, such as matching the closing brace at the correct nesting level, or extract the full media query block using a brace-counting approach.
 
-### [Info] CR-5: All tests use `asyncio.run()` directly instead of pytest-asyncio
+### [Low] CR-4: Tests read HTML files from disk on every test method invocation
 
-- **File**: `tests/test_coverage_gaps.py:122, 139, 189, 216`
-- **Issue**: The project has `pytest-asyncio` installed, but the PR uses `asyncio.run()` to invoke async functions. This is consistent with the existing pattern in `test_websocket_handler.py` and `test_websocket_auth.py`, so this is not a deviation. Noted for awareness only -- if the project migrates to `async def test_*` with `pytest-asyncio`, these tests will need updating.
-- **Blocking**: No.
+- **File**: `tests/test_viewport_responsive.py:15-21`
+- **Issue**: Each of the 9 tests calls `_read_webrtc()` or `_read_scroll_lock()`, performing file I/O on every invocation. For a file this size (~25K tokens), this is negligible in absolute terms but could be avoided by reading once at class or module level.
+- **Blocking**: No. Performance impact is trivial.
+- **Suggestion**: Use a `@pytest.fixture(scope="module")` or class-level `setup_class` to read the file once.
+
+### [Info] CR-5: `app.py:209` still has `height=900` -- intentional per issue scope
+
+- **File**: `app.py:209` (`st.components.v1.html(html_content, height=900, scrolling=False)`)
+- **Issue**: The `height=900` parameter remains. Per the issue scope: "app.py의 height=900 파라미터 제거 (CSS가 덮어쓰므로 폴백으로 유지)." This is intentional -- `scroll_lock.html`'s `!important` overrides Streamlit's inline `style="height: 900px"`, but keeping the value ensures Streamlit's component API receives a valid height (some Streamlit versions require a numeric height).
+- **Blocking**: No. This is correctly scoped out.
 
 ---
 
 ### Security Findings
 
-### [Low] SEC-1: Mock AWS credential strings in test patches
+No security issues identified.
 
-- **File**: `tests/test_coverage_gaps.py:64-66`
-- **Issue**: The test patches `get_aws_access_key_id` with `return_value="key"` and `get_aws_secret_access_key` with `return_value="secret"`. These are obviously fake values and never reach any AWS endpoint (boto3.client is also mocked). However, the pattern of using credential-like strings in tests should ideally use clearly marked dummy values (e.g., `"FAKE_ACCESS_KEY_FOR_TESTING"`).
-- **Mitigating factors**: The values never leave the test process. `boto3.client` is fully mocked. No real AWS calls are made.
-- **Blocking**: No.
+- The CSS changes are in static HTML files served from the server filesystem. No user input reaches these files.
+- `scroll_lock.html` is injected via `st.markdown(unsafe_allow_html=True)`, but its content is a static file read from disk, not constructed from user input.
+- No new JavaScript is introduced.
+- No authentication, authorization, or data handling changes.
+
+---
+
+## AC Verification
+
+| AC | Status | Notes |
+|----|--------|-------|
+| 1080p display fills viewport | Pass | `100vh` on iframe + `100%` on body = full viewport coverage |
+| 768px laptop no clipping | Pass | Media query updated to `100%`, status chip/button use `position: fixed` with bottom offsets |
+| 4K monitor no empty space | Pass | `100vh` scales to any viewport height |
+| Fullscreen round-trip unchanged | Pass | `#viewer:fullscreen` CSS untouched, 2 regression tests confirm `100vh` remains |
+| FAB/settings positions correct | Pass | All positioned elements use `fixed`/`absolute` with `top`/`right`/`bottom` offsets, unaffected by body height |
 
 ---
 
 ## Verdict
 
-**REQUEST_CHANGES**
+**APPROVE**
 
-**Blocking issue**: CR-1 (test isolation). The `TestInitSessionState` tests mutate shared module-level state without cleanup between tests. While they currently pass due to favorable test ordering, any reordering (e.g., `pytest-randomly`) could cause spurious failures. The fix is to adopt the `monkeypatch` autouse fixture pattern already established in `test_auth_module.py`.
+The PR is clean, minimal, and correctly solves the stated problem. All 9 tests pass. The CSS approach (parent sets iframe to `100vh`, child uses `100%`) is the correct way to handle iframe-within-viewport sizing. No blocking issues found.
 
-**Non-blocking suggestions** (can be addressed in follow-up):
-- CR-2: Extract `SessionState` to shared module
-- CR-3: Strengthen language_update test with follow-up transcript
-- CR-4: Add `pytest` import and fixture usage
+**Non-blocking suggestions for follow-up:**
+- CR-2: Add `100dvh` for mobile Safari compatibility
+- CR-3: Harden media query test regex patterns
 
 ---
 
 ## Follow-ups
 
-1. **[Follow-up] Extract `SessionState` to `tests/conftest.py`** -- Deduplicate the helper class shared between `test_auth_module.py` and `test_coverage_gaps.py` (CR-2, RL-001). Estimated: 10 minutes.
+1. **[Follow-up] Add `100dvh` fallback for iOS Safari** -- Apply `height: 100dvh !important` as a progressive enhancement after `height: 100vh !important` in `scroll_lock.html`. This eliminates the iOS Safari address-bar-overlap issue for all `100vh` usages. Estimated: 15 minutes. (CR-2)
 
-2. **[Follow-up] Add integration-level language_update test** -- Verify that a `language_update` message actually affects subsequent `transcript` processing, not just the echo response (CR-3). Estimated: 20 minutes.
+2. **[Follow-up] Address `body margin-top: 5%` + `height: 100%` interaction** -- Consider whether the 5% top margin should be converted to `padding-top` or the height adjusted to `calc(100% - 5%)` to avoid the silent overflow clip. Estimated: 10 minutes. (CR-1)

--- a/tests/test_viewport_responsive.py
+++ b/tests/test_viewport_responsive.py
@@ -1,0 +1,98 @@
+"""
+ISSUE-36: webrtc.html 뷰포트 반응형 높이 적용 테스트
+- webrtc.html body에 90vh 하드코딩이 없는지 확인
+- scroll_lock.html에 iframe 100vh 규칙이 존재하는지 확인
+- 미디어쿼리에서도 90vh가 제거되었는지 확인
+"""
+
+import re
+from pathlib import Path
+
+WEBRTC_HTML = Path(__file__).parent.parent / "components" / "webrtc.html"
+SCROLL_LOCK_HTML = Path(__file__).parent.parent / "components" / "scroll_lock.html"
+
+
+def _read_webrtc():
+    return WEBRTC_HTML.read_text(encoding="utf-8")
+
+
+def _read_scroll_lock():
+    return SCROLL_LOCK_HTML.read_text(encoding="utf-8")
+
+
+def _get_body_css():
+    html = _read_webrtc()
+    m = re.search(r"body\s*\{[^}]*\}", html)
+    assert m is not None, "body CSS block not found"
+    return m.group(0)
+
+
+class TestWebrtcBodyHeight:
+    """webrtc.html body에서 90vh가 제거되고 100%로 변경되었는지 확인"""
+
+    def test_body_no_90vh_height(self):
+        """body 스타일에 height: 90vh가 없어야 한다"""
+        body_css = _get_body_css()
+        assert "90vh" not in body_css
+
+    def test_body_uses_100_percent_height(self):
+        """body 스타일이 height: 100%를 사용해야 한다"""
+        body_css = _get_body_css()
+        assert "height: 100%" in body_css
+
+    def test_body_uses_100_percent_max_height(self):
+        """body 스타일이 max-height: 100%를 사용해야 한다"""
+        body_css = _get_body_css()
+        assert "max-height: 100%" in body_css
+
+
+class TestMediaQueryHeight:
+    """미디어쿼리에서 body의 90vh 참조가 제거되었는지 확인"""
+
+    def test_max_width_768_no_90vh(self):
+        """@media (max-width: 768px) body에 90vh가 없어야 한다"""
+        html = _read_webrtc()
+        pattern = r"@media\s*\(max-width:\s*768px\)\s*\{(.*?)\n\s*\n"
+        m = re.search(pattern, html, re.DOTALL)
+        assert m is not None, "max-width: 768px media query not found"
+        assert "90vh" not in m.group(1)
+
+    def test_max_height_600_no_90vh(self):
+        """@media (max-height: 600px) body에 90vh가 없어야 한다"""
+        html = _read_webrtc()
+        pattern = r"@media\s*\(max-height:\s*600px\)\s*\{(.*?)\n\s*\n"
+        m = re.search(pattern, html, re.DOTALL)
+        assert m is not None, "max-height: 600px media query not found"
+        assert "90vh" not in m.group(1)
+
+
+class TestScrollLockIframeHeight:
+    """scroll_lock.html에서 iframe을 뷰포트 높이에 맞추는 규칙 확인"""
+
+    def test_iframe_has_100vh_height(self):
+        """scroll_lock.html의 .main iframe에 height: 100vh가 있어야 한다"""
+        css = _read_scroll_lock()
+        assert "height: 100vh" in css
+
+    def test_iframe_height_uses_important(self):
+        """iframe height에 !important가 있어야 한다"""
+        css = _read_scroll_lock()
+        assert "height: 100vh !important" in css
+
+
+class TestFullscreenUnaffected:
+    """전체화면 CSS가 변경되지 않았는지 확인 (regression)"""
+
+    def test_fullscreen_still_uses_100vh(self):
+        """#viewer:fullscreen은 여전히 height: 100vh를 사용해야 한다"""
+        html = _read_webrtc()
+        m = re.search(r"#viewer:fullscreen\s*\{[^}]*\}", html)
+        assert m is not None, "#viewer:fullscreen CSS not found"
+        assert "height: 100vh" in m.group(0)
+
+    def test_webkit_fullscreen_still_uses_100vh(self):
+        """#viewer:-webkit-full-screen은 여전히 100vh를 사용해야 한다"""
+        html = _read_webrtc()
+        m = re.search(r"#viewer:-webkit-full-screen\s*\{[^}]*\}", html)
+        assert m is not None, "-webkit-full-screen CSS not found"
+        assert "height: 100vh" in m.group(0)


### PR DESCRIPTION
Closes #56

## Summary
- `scroll_lock.html`: `.main iframe`에 `height: 100vh !important` 추가 — 부모 페이지의 vh가 브라우저 뷰포트 기준이므로 iframe이 화면을 꽉 채움
- `webrtc.html`: body `height: 90vh` → `100%`, 미디어쿼리(@media <=768px, <=600px)도 동일 적용
- `app.py`의 `height=900`은 유지 (CSS !important가 덮어쓰므로 Streamlit API 폴백 역할)
- 전체화면 모드 영향 없음 — Fullscreen API는 iframe과 별개 레이어

## Test plan
- [x] 9개 신규 테스트 추가 (`tests/test_viewport_responsive.py`)
- [x] body에 `90vh` 하드코딩 없음 확인
- [x] `scroll_lock.html`에 `height: 100vh !important` 존재 확인
- [x] 미디어쿼리에서 `90vh` 제거 확인
- [x] 전체화면 CSS regression 없음 확인
- [x] 기존 전체 테스트 322개 통과, 85.49% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)