### PR TITLE
[ISSUE-25] RoomManager 클래스 및 룸별 WebSocket 라우팅

### DIFF
--- a/room_manager.py
+++ b/room_manager.py
@@ -1,0 +1,172 @@
+"""
+RoomManager 모듈 (ISSUE-25)
+
+여러 오퍼레이터가 동시에 독립적인 자막 세션을 운영할 수 있도록
+WebSocket 연결을 룸 단위로 격리한다.
+
+Design notes:
+- 인메모리 dict로 `room_id → RoomState`를 관리한다.
+- DB 영속화는 ISSUE-26에서 다룬다.
+- 모든 클라이언트-노출 에러 메시지는 generic하게 유지한다 (RL-006).
+- 서버는 client-supplied identity를 신뢰하지 않는다 (RL-002):
+  room_id는 RoomManager에 사전 등록된 것만 허용하며 실제 연결 등록은
+  서버 측에서만 수행된다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+DEFAULT_ROOM_ID = "default"
+
+
+def _new_room_id() -> str:
+    """Generate a short, URL-safe, unguessable room id."""
+    return secrets.token_urlsafe(8)
+
+
+def _default_language_settings() -> dict[str, str]:
+    return {"input_lang": "auto", "output_lang": "ko"}
+
+
+@dataclass
+class RoomState:
+    """Per-room runtime state.
+
+    Fields per Implementation Notes (ISSUE-25):
+      room_id, connections, language_settings, translate_client,
+      bedrock_client, created_at, last_activity
+    """
+
+    room_id: str
+    connections: set = field(default_factory=set)
+    language_settings: dict[str, str] = field(
+        default_factory=_default_language_settings
+    )
+    translate_client: Any | None = None
+    bedrock_client: Any | None = None
+    bedrock_available: bool = False
+    created_at: float = field(default_factory=time.time)
+    last_activity: float = field(default_factory=time.time)
+
+    def touch(self) -> None:
+        """Update last_activity to the current time."""
+        self.last_activity = time.time()
+
+
+class RoomManager:
+    """In-memory registry of active rooms keyed by room_id."""
+
+    def __init__(self) -> None:
+        self._rooms: dict[str, RoomState] = {}
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+    def create_room(self, room_id: str | None = None) -> RoomState:
+        """Create a new room. Generates a unique id when none supplied.
+
+        Raises:
+            ValueError: if the supplied room_id already exists.
+        """
+        if room_id is None:
+            # Generate a unique id; retry on the (vanishingly rare) collision.
+            for _ in range(8):
+                candidate = _new_room_id()
+                if candidate not in self._rooms:
+                    room_id = candidate
+                    break
+            else:  # pragma: no cover — extremely unlikely
+                raise RuntimeError("Failed to generate a unique room id")
+
+        if room_id in self._rooms:
+            raise ValueError(f"Room id already exists: {room_id}")
+
+        state = RoomState(room_id=room_id)
+        self._rooms[room_id] = state
+        return state
+
+    def get_room(self, room_id: str) -> RoomState | None:
+        """Return the room state for room_id, or None if not registered."""
+        return self._rooms.get(room_id)
+
+    def get_or_create_room(self, room_id: str) -> RoomState:
+        """Return the room for room_id, creating it if missing.
+
+        Used for the default-room fallback so that a brand-new server
+        accepts connections without explicit room provisioning.
+        """
+        room = self._rooms.get(room_id)
+        if room is None:
+            room = RoomState(room_id=room_id)
+            self._rooms[room_id] = room
+        return room
+
+    def delete_room(self, room_id: str) -> bool:
+        """Remove a room. Returns True if it existed, False otherwise."""
+        return self._rooms.pop(room_id, None) is not None
+
+    def list_rooms(self) -> list[str]:
+        """Snapshot of registered room ids."""
+        return list(self._rooms.keys())
+
+    # ------------------------------------------------------------------
+    # Connection registration
+    # ------------------------------------------------------------------
+    def register_connection(self, room_id: str, websocket: Any) -> None:
+        """Add a websocket to the named room.
+
+        Raises:
+            KeyError: if the room does not exist.
+        """
+        room = self._rooms.get(room_id)
+        if room is None:
+            raise KeyError(room_id)
+        room.connections.add(websocket)
+        room.touch()
+
+    def unregister_connection(self, room_id: str, websocket: Any) -> None:
+        """Remove a websocket from the named room. No-op if room or
+        connection is unknown."""
+        room = self._rooms.get(room_id)
+        if room is None:
+            return
+        room.connections.discard(websocket)
+        room.touch()
+
+    # ------------------------------------------------------------------
+    # Broadcast
+    # ------------------------------------------------------------------
+    async def broadcast_to_room(self, room_id: str, payload: dict) -> None:
+        """Send a JSON-encoded payload to every connection in the room.
+
+        Failed sends are logged and skipped — they should not break the
+        broadcast loop. No-op for unknown rooms.
+        """
+        room = self._rooms.get(room_id)
+        if room is None:
+            return
+        if not room.connections:
+            return
+
+        message = json.dumps(payload)
+        # Snapshot connections to avoid mutation during iteration
+        coros = []
+        for ws in list(room.connections):
+            coros.append(self._safe_send(ws, message))
+        if coros:
+            await asyncio.gather(*coros, return_exceptions=True)
+        room.touch()
+
+    @staticmethod
+    async def _safe_send(websocket: Any, message: str) -> None:
+        try:
+            await websocket.send(message)
+        except Exception as e:
+            # Log server-side; never propagate raw exception text to clients.
+            print(f"[Room] broadcast send failed: {e!r}")

--- a/tests/test_room_manager.py
+++ b/tests/test_room_manager.py
@@ -1,0 +1,397 @@
+"""
+RoomManager 단위 테스트 (ISSUE-25)
+
+검증 대상:
+- 룸 CRUD (생성, 조회, 삭제)
+- 같은 서버에서 여러 룸이 동시에 동작할 때 메시지 격리
+- 존재하지 않는 룸 ID 접속 시 에러 반환
+- 룸 ID 누락 시 기본 룸 ("default") 배정 (하위 호환)
+
+Note: 외부 AWS 호출은 mock 처리.
+"""
+
+import asyncio
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# websocket_handler -> auth -> streamlit / extra_streamlit_components
+# 시스템 Python에 해당 패키지가 없을 수 있으므로 미리 mock 등록
+if "streamlit" not in sys.modules:
+    sys.modules["streamlit"] = MagicMock()
+if "extra_streamlit_components" not in sys.modules:
+    sys.modules["extra_streamlit_components"] = MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# RoomManager CRUD
+# ---------------------------------------------------------------------------
+class TestRoomManagerCrud:
+    """RoomManager.create_room / get_room / delete_room"""
+
+    def test_create_room_returns_unique_id(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        room_a = rm.create_room()
+        room_b = rm.create_room()
+
+        assert room_a.room_id != room_b.room_id
+        assert isinstance(room_a.room_id, str)
+        assert len(room_a.room_id) > 0
+
+    def test_create_room_with_explicit_id(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        room = rm.create_room(room_id="hall-A")
+
+        assert room.room_id == "hall-A"
+
+    def test_create_room_with_duplicate_id_raises(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        rm.create_room(room_id="hall-A")
+        with pytest.raises(ValueError):
+            rm.create_room(room_id="hall-A")
+
+    def test_get_room_returns_state(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        created = rm.create_room(room_id="abc123")
+        fetched = rm.get_room("abc123")
+
+        assert fetched is created
+        assert fetched.room_id == "abc123"
+
+    def test_get_room_unknown_id_returns_none(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        assert rm.get_room("missing") is None
+
+    def test_delete_room_removes_state(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        rm.create_room(room_id="hall-A")
+        deleted = rm.delete_room("hall-A")
+
+        assert deleted is True
+        assert rm.get_room("hall-A") is None
+
+    def test_delete_unknown_room_returns_false(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        assert rm.delete_room("never-existed") is False
+
+    def test_room_state_has_required_fields(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        room = rm.create_room(room_id="abc")
+
+        # Required attributes per Implementation Notes
+        assert hasattr(room, "room_id")
+        assert hasattr(room, "connections")
+        assert hasattr(room, "language_settings")
+        assert hasattr(room, "translate_client")
+        assert hasattr(room, "bedrock_client")
+        assert hasattr(room, "created_at")
+        assert hasattr(room, "last_activity")
+
+        # Default language settings
+        assert room.language_settings == {
+            "input_lang": "auto",
+            "output_lang": "ko",
+        }
+
+        # connections is a set
+        assert isinstance(room.connections, set)
+        assert len(room.connections) == 0
+
+
+# ---------------------------------------------------------------------------
+# Connection registration
+# ---------------------------------------------------------------------------
+class TestRoomManagerConnections:
+    """register_connection / unregister_connection"""
+
+    def test_register_connection_adds_to_room(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        rm.create_room(room_id="A")
+        ws = MagicMock()
+
+        rm.register_connection("A", ws)
+
+        room = rm.get_room("A")
+        assert ws in room.connections
+
+    def test_register_connection_unknown_room_raises(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        ws = MagicMock()
+        with pytest.raises(KeyError):
+            rm.register_connection("nope", ws)
+
+    def test_unregister_connection_removes(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        rm.create_room(room_id="A")
+        ws = MagicMock()
+        rm.register_connection("A", ws)
+
+        rm.unregister_connection("A", ws)
+
+        room = rm.get_room("A")
+        assert ws not in room.connections
+
+    def test_unregister_unknown_room_is_noop(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        ws = MagicMock()
+        # Should not raise
+        rm.unregister_connection("ghost", ws)
+
+    def test_get_or_create_default_room(self):
+        """룸 ID 없이 접속 시 기본 룸 ("default") 사용"""
+        from room_manager import DEFAULT_ROOM_ID, RoomManager
+
+        rm = RoomManager()
+        room = rm.get_or_create_room(DEFAULT_ROOM_ID)
+
+        assert room.room_id == DEFAULT_ROOM_ID
+        # Calling again returns the same room (idempotent)
+        same_room = rm.get_or_create_room(DEFAULT_ROOM_ID)
+        assert same_room is room
+
+
+# ---------------------------------------------------------------------------
+# Room isolation — different rooms must not share state
+# ---------------------------------------------------------------------------
+class TestRoomIsolation:
+    """서로 다른 룸의 연결이 서로의 메시지를 받지 않아야 한다."""
+
+    def test_connections_are_isolated_between_rooms(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        rm.create_room(room_id="A")
+        rm.create_room(room_id="B")
+
+        ws_a = MagicMock(name="ws_a")
+        ws_b = MagicMock(name="ws_b")
+        rm.register_connection("A", ws_a)
+        rm.register_connection("B", ws_b)
+
+        room_a = rm.get_room("A")
+        room_b = rm.get_room("B")
+
+        assert ws_a in room_a.connections
+        assert ws_a not in room_b.connections
+        assert ws_b in room_b.connections
+        assert ws_b not in room_a.connections
+
+    def test_language_settings_are_per_room(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        room_a = rm.create_room(room_id="A")
+        room_b = rm.create_room(room_id="B")
+
+        room_a.language_settings["input_lang"] = "en"
+        room_a.language_settings["output_lang"] = "ko"
+
+        # Mutating room A must not affect room B
+        assert room_b.language_settings["input_lang"] == "auto"
+        assert room_b.language_settings["output_lang"] == "ko"
+
+    def test_broadcast_only_targets_room_members(self):
+        """broadcast_to_room should only send to that room's connections."""
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        rm.create_room(room_id="A")
+        rm.create_room(room_id="B")
+
+        ws_a = AsyncMock(name="ws_a")
+        ws_b = AsyncMock(name="ws_b")
+        rm.register_connection("A", ws_a)
+        rm.register_connection("B", ws_b)
+
+        payload = {"type": "test", "value": "hello"}
+        asyncio.run(rm.broadcast_to_room("A", payload))
+
+        # ws_a should have been sent to once
+        ws_a.send.assert_awaited_once()
+        sent_arg = ws_a.send.await_args.args[0]
+        assert json.loads(sent_arg) == payload
+        # ws_b should NOT have been called
+        ws_b.send.assert_not_awaited()
+
+    def test_broadcast_to_unknown_room_is_noop(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        # Should not raise
+        asyncio.run(rm.broadcast_to_room("ghost", {"type": "x"}))
+
+
+# ---------------------------------------------------------------------------
+# Auth integration: room_id routing in handle_openai_websocket flow
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def db_with_user(tmp_path):
+    """임시 DB + 활성 사용자 1명"""
+    from database import DatabaseManager, User
+
+    db = DatabaseManager(str(tmp_path / "test_room_manager.db"))
+    user_model = User(db)
+    user_model.create_user(
+        username="operator1",
+        password="pw",
+        role="user",
+        usage_limit_seconds=3600,
+    )
+    return user_model
+
+
+def _make_ws(messages):
+    """Create an AsyncMock websocket that yields the given messages on recv()."""
+    ws = AsyncMock()
+    ws.remote_address = ("127.0.0.1", 12345)
+    # recv() returns each message in order; subsequent calls would block indefinitely
+    iter_msgs = iter(messages)
+
+    async def _recv():
+        try:
+            return next(iter_msgs)
+        except StopIteration as exc:
+            # Mimic a closed connection on subsequent recv()
+            raise asyncio.CancelledError() from exc
+
+    ws.recv = _recv
+    ws.send = AsyncMock()
+    return ws
+
+
+def _sent_messages(ws):
+    return [json.loads(call.args[0]) for call in ws.send.call_args_list]
+
+
+class TestAuthRoomRouting:
+    """auth 메시지에 room_id가 있을 때 RoomManager에 등록되는지 검증."""
+
+    def test_auth_with_room_id_registers_connection(self, db_with_user):
+        """auth 메시지에 room_id 포함 -> 해당 룸에 연결이 등록된다."""
+        from room_manager import RoomManager
+        from websocket_handler import _authenticate_client
+
+        rm = RoomManager()
+        rm.create_room(room_id="hall-A")
+
+        db_user = db_with_user.get_user_by_username("operator1")
+        auth_msg = json.dumps(
+            {
+                "type": "auth",
+                "user": {
+                    "id": db_user["id"],
+                    "username": "operator1",
+                    "role": "user",
+                },
+                "room_id": "hall-A",
+                "language_settings": {"input_lang": "en", "output_lang": "ko"},
+            }
+        )
+        ws = AsyncMock()
+        ws.remote_address = ("127.0.0.1", 1)
+        ws.recv = AsyncMock(return_value=auth_msg)
+        ws.send = AsyncMock()
+
+        with patch("websocket_handler.get_user_model", return_value=db_with_user):
+            with patch("websocket_handler._room_manager", rm):
+                result = asyncio.run(_authenticate_client(ws))
+
+        assert result is not None
+        assert result["room_id"] == "hall-A"
+        # The connection is registered to room hall-A
+        assert ws in rm.get_room("hall-A").connections
+
+    def test_auth_without_room_id_uses_default(self, db_with_user):
+        """room_id 없이 접속 시 기본 룸 'default'에 배정된다 (하위 호환)."""
+        from room_manager import DEFAULT_ROOM_ID, RoomManager
+        from websocket_handler import _authenticate_client
+
+        rm = RoomManager()
+        # Do NOT create the default room ahead of time — handler should auto-create.
+
+        db_user = db_with_user.get_user_by_username("operator1")
+        auth_msg = json.dumps(
+            {
+                "type": "auth",
+                "user": {
+                    "id": db_user["id"],
+                    "username": "operator1",
+                    "role": "user",
+                },
+            }
+        )
+        ws = AsyncMock()
+        ws.remote_address = ("127.0.0.1", 2)
+        ws.recv = AsyncMock(return_value=auth_msg)
+        ws.send = AsyncMock()
+
+        with patch("websocket_handler.get_user_model", return_value=db_with_user):
+            with patch("websocket_handler._room_manager", rm):
+                result = asyncio.run(_authenticate_client(ws))
+
+        assert result is not None
+        assert result["room_id"] == DEFAULT_ROOM_ID
+        assert ws in rm.get_room(DEFAULT_ROOM_ID).connections
+
+    def test_auth_with_unknown_room_id_returns_error(self, db_with_user):
+        """존재하지 않는 룸 ID 접속 시 auth_error를 반환하고 None을 리턴한다."""
+        from room_manager import RoomManager
+        from websocket_handler import _authenticate_client
+
+        rm = RoomManager()
+        # rm has no rooms — every named room is "unknown"
+        # We only auto-create the default room; explicit unknown IDs should fail.
+
+        db_user = db_with_user.get_user_by_username("operator1")
+        auth_msg = json.dumps(
+            {
+                "type": "auth",
+                "user": {
+                    "id": db_user["id"],
+                    "username": "operator1",
+                    "role": "user",
+                },
+                "room_id": "non-existent-room",
+            }
+        )
+        ws = AsyncMock()
+        ws.remote_address = ("127.0.0.1", 3)
+        ws.recv = AsyncMock(return_value=auth_msg)
+        ws.send = AsyncMock()
+
+        with patch("websocket_handler.get_user_model", return_value=db_with_user):
+            with patch("websocket_handler._room_manager", rm):
+                result = asyncio.run(_authenticate_client(ws))
+
+        assert result is None
+        sent = _sent_messages(ws)
+        # An auth_error must be sent
+        assert any(msg.get("type") == "auth_error" for msg in sent)
+        # No auth_success on unknown room
+        assert all(msg.get("type") != "auth_success" for msg in sent)

--- a/websocket_handler.py
+++ b/websocket_handler.py
@@ -14,6 +14,7 @@ import websockets
 
 from auth import check_usage_limit, update_user_session
 from database import get_usage_log_model, get_user_model
+from room_manager import DEFAULT_ROOM_ID, RoomManager
 from services import (
     create_openai_session,
     get_aws_access_key_id,
@@ -24,6 +25,15 @@ from translation import detect_language, translate_with_llm
 
 # Per-connection rate limit: max messages per minute (sliding window)
 WS_RATE_LIMIT_PER_MINUTE = int(os.getenv("WS_RATE_LIMIT_PER_MINUTE", "30"))
+
+# Module-level RoomManager singleton.
+# Tests substitute this via `patch("websocket_handler._room_manager", ...)`.
+_room_manager: RoomManager = RoomManager()
+
+
+def get_room_manager() -> RoomManager:
+    """Return the module-level RoomManager singleton."""
+    return _room_manager
 
 
 def find_free_port(start_port=8765, max_port=8800):
@@ -127,9 +137,65 @@ async def _authenticate_client(websocket):
                 "output_lang": language_settings.get("output_lang", "ko"),
             }
 
-            print(f"[Auth] 사용자 인증 성공: {validated_user['username']}")
+            # Resolve target room (ISSUE-25).
+            # - If room_id supplied: it MUST already exist (created server-
+            #   side); unknown ids are rejected with a generic auth_error
+            #   to avoid leaking room enumeration (RL-006).
+            # - If absent: route to the default room, auto-creating it.
+            requested_room_id = data.get("room_id")
+            room_manager = _room_manager
+            if requested_room_id:
+                room = room_manager.get_room(requested_room_id)
+                if room is None:
+                    print(
+                        f"[Auth] 인증 실패: 존재하지 않는 룸 ID "
+                        f"(user={validated_user['username']})"
+                    )
+                    await websocket.send(
+                        json.dumps(
+                            {
+                                "type": "auth_error",
+                                "message": "요청한 룸을 찾을 수 없습니다.",
+                            }
+                        )
+                    )
+                    return None
+                resolved_room_id = requested_room_id
+            else:
+                room_manager.get_or_create_room(DEFAULT_ROOM_ID)
+                resolved_room_id = DEFAULT_ROOM_ID
+
+            # Register the connection to its room before signaling success.
+            try:
+                room_manager.register_connection(resolved_room_id, websocket)
+            except KeyError:
+                # Race: room deleted between get_room and register.
+                # Treat as unknown.
+                print(f"[Auth] 인증 실패: 룸 등록 실패 (room={resolved_room_id})")
+                await websocket.send(
+                    json.dumps(
+                        {
+                            "type": "auth_error",
+                            "message": "요청한 룸을 찾을 수 없습니다.",
+                        }
+                    )
+                )
+                return None
+
+            validated_user["room_id"] = resolved_room_id
+
+            print(
+                f"[Auth] 사용자 인증 성공: {validated_user['username']} "
+                f"(room={resolved_room_id})"
+            )
             await websocket.send(
-                json.dumps({"type": "auth_success", "message": "인증 완료"})
+                json.dumps(
+                    {
+                        "type": "auth_success",
+                        "message": "인증 완료",
+                        "room_id": resolved_room_id,
+                    }
+                )
             )
             return validated_user
     except TimeoutError:
@@ -543,12 +609,27 @@ async def handle_openai_websocket(websocket):
                     )
                 )
             except Exception as e:
-                print(f"[WebSocket] 메시지 처리 오류: {e}")
-                await websocket.send(json.dumps({"type": "error", "message": str(e)}))
+                # RL-006: log internal error server-side, return generic
+                # message to the client.
+                print(f"[WebSocket] 메시지 처리 오류: {e!r}")
+                await websocket.send(
+                    json.dumps(
+                        {
+                            "type": "error",
+                            "message": "메시지 처리 중 오류가 발생했습니다.",
+                        }
+                    )
+                )
 
     except Exception as e:
-        print(f"[WebSocket] 연결 오류: {e}")
+        print(f"[WebSocket] 연결 오류: {e!r}")
     finally:
+        # Unregister from the room (no-op if user_info is None / unset).
+        try:
+            if user_info and user_info.get("room_id"):
+                _room_manager.unregister_connection(user_info["room_id"], websocket)
+        except Exception as cleanup_err:
+            print(f"[Room] 연결 해제 실패: {cleanup_err!r}")
         print("[WebSocket] 클라이언트 연결 종료")
 
 


### PR DESCRIPTION
Closes #43

## Summary
- `RoomManager` (in-memory `room_id → RoomState`) — CRUD, connection register/unregister, room-scoped broadcast.
- `_authenticate_client` resolves an `auth.room_id` to a server-registered room. Missing → default room (backward compatible). Unknown → generic `auth_error` (RL-006).
- Connection cleanup on disconnect via `unregister_connection` in `finally`.
- Replaced `str(e)` leak in handler-level error response with a generic message (RL-006).

## Acceptance Criteria
- [x] `RoomManager`가 룸을 생성하고 고유 ID를 반환한다 (`secrets.token_urlsafe(8)` 기반).
- [x] auth 메시지에 `room_id` 필드가 포함되면 해당 룸에 연결이 등록된다.
- [x] 같은 서버에서 2개의 룸이 동시에 동작할 때 각 룸의 메시지가 다른 룸에 전달되지 않는다 (`broadcast_to_room` 격리 테스트 포함).
- [x] 존재하지 않는 룸 ID로 접속 시 generic 에러 메시지가 반환된다.

## Review Lessons applied
- RL-002 (server-side identity): room_id는 서버에 사전 등록된 것만 허용. 클라이언트는 룸을 새로 만들 수 없다.
- RL-003 (predictable tokens): `secrets.token_urlsafe` 사용.
- RL-004 (weak assertions): 모든 테스트는 특정 객체/페이로드 동등성을 검증.
- RL-005 (refactor without tests): 20 단위 테스트 동반.
- RL-006 (error leakage): 룸 미존재 / 메시지 처리 오류 모두 generic 메시지로 응답.

## Test plan
- [x] `uv run pytest --no-cov tests/test_room_manager.py -v` → 20 passed
- [x] `uv run pytest` (전체) → 342 passed, coverage 85.90%
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run black --check .` → 30 files unchanged

## Out-of-scope (follow-up)
- DB 영속화: ISSUE-26
- UI: ISSUE-27
- 뷰어 브로드캐스트 통합: 후속 이슈