### PR TITLE
[ISSUE-26] rooms 테이블 및 룸 라이프사이클 관리

### DIFF
--- a/database.py
+++ b/database.py
@@ -7,10 +7,32 @@ import json
 import os
 import sqlite3
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 import bcrypt
+
+
+class InvalidRoomTransition(ValueError):
+    """Raised when a room status transition violates the lifecycle diagram.
+
+    Diagram (ISSUE-26):
+        waiting  → active | closed
+        active   → inactive | closed
+        inactive → active | closed
+        closed   → (terminal)
+    """
+
+
+# Allowed status transitions for rooms (ISSUE-26).
+# Source: issues.md ISSUE-26 state-transition diagram.
+_ROOM_VALID_STATUSES: tuple[str, ...] = ("waiting", "active", "inactive", "closed")
+_ROOM_TRANSITIONS: dict[str, set[str]] = {
+    "waiting": {"active", "closed"},
+    "active": {"inactive", "closed"},
+    "inactive": {"active", "closed"},
+    "closed": set(),  # terminal
+}
 
 
 class DatabaseManager:
@@ -83,6 +105,39 @@ class DatabaseManager:
                 """
                 CREATE INDEX IF NOT EXISTS idx_usage_logs_created_at
                 ON usage_logs(created_at)
+            """
+            )
+
+            # rooms 테이블 생성 (ISSUE-26)
+            # 룸 라이프사이클을 DB에 영속화한다. 상태 전이는 application
+            # 레이어 (Room.transition_status) 에서 강제하며, DB 레벨의
+            # CHECK 제약은 검증된 application path 우회를 막기 위한
+            # 방어선 역할이다.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS rooms (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'waiting'
+                        CHECK (status IN ('waiting','active','inactive','closed')),
+                    input_lang TEXT NOT NULL DEFAULT 'auto',
+                    output_lang TEXT NOT NULL DEFAULT 'ko',
+                    created_by INTEGER NOT NULL,
+                    operator_id INTEGER,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    last_activity TIMESTAMP,
+                    timeout_minutes INTEGER NOT NULL DEFAULT 30,
+                    closed_at TIMESTAMP,
+                    FOREIGN KEY (created_by) REFERENCES users(id),
+                    FOREIGN KEY (operator_id) REFERENCES users(id)
+                )
+            """
+            )
+            # status 필터 (cleanup_stale_rooms, list_by_status, hydrate)
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_rooms_status
+                ON rooms(status)
             """
             )
 
@@ -534,6 +589,219 @@ class UsageLog:
             return stats
 
 
+class Room:
+    """rooms 테이블에 대한 CRUD + 상태 전이 (ISSUE-26).
+
+    - 상태 전이는 _ROOM_TRANSITIONS 다이어그램에 따라 application
+      레이어에서 강제한다 (CHECK 제약은 fallback 방어선).
+    - cleanup_stale_rooms() 는 timeout_minutes 를 초과한 active/inactive
+      룸을 closed 처리한다 (좀비 룸 정리).
+    - 모든 메서드는 외부에서 SQLite tmp_path 로 격리 가능하도록
+      DatabaseManager 인스턴스 주입을 받는다.
+    """
+
+    # Statuses that should be re-loaded into RoomManager on server restart.
+    # Closed rooms are terminal and stay only in the audit trail.
+    HYDRATABLE_STATUSES: tuple[str, ...] = ("waiting", "active", "inactive")
+
+    def __init__(self, db_manager: DatabaseManager):
+        self.db = db_manager
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+    def create(
+        self,
+        room_id: str,
+        name: str,
+        created_by: int,
+        input_lang: str = "auto",
+        output_lang: str = "ko",
+        timeout_minutes: int = 30,
+        operator_id: int | None = None,
+    ) -> dict[str, Any] | None:
+        """룸 행을 생성하고 created row 를 dict 로 반환한다.
+
+        Returns None on PK collision (mirrors User.create_user semantics).
+        Raises sqlite3.IntegrityError when FK references are invalid —
+        callers that pass user-provided created_by/operator_id should
+        handle this explicitly so that the failure is not silent.
+        """
+        try:
+            with self.db.get_connection() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO rooms (
+                        id, name, status, input_lang, output_lang,
+                        created_by, operator_id, last_activity,
+                        timeout_minutes
+                    ) VALUES (?, ?, 'waiting', ?, ?, ?, ?,
+                              CURRENT_TIMESTAMP, ?)
+                    """,
+                    (
+                        room_id,
+                        name,
+                        input_lang,
+                        output_lang,
+                        created_by,
+                        operator_id,
+                        timeout_minutes,
+                    ),
+                )
+                conn.commit()
+        except sqlite3.IntegrityError as e:
+            # PK 충돌은 None, FK 위반은 그대로 전파
+            msg = str(e).lower()
+            if "unique" in msg or "primary key" in msg:
+                return None
+            raise
+
+        return self.get_by_id(room_id)
+
+    def get_by_id(self, room_id: str) -> dict[str, Any] | None:
+        with self.db.get_connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM rooms WHERE id = ?", (room_id,)
+            ).fetchone()
+            return dict(row) if row else None
+
+    def list_all(self) -> list[dict[str, Any]]:
+        with self.db.get_connection() as conn:
+            cursor = conn.execute("SELECT * FROM rooms ORDER BY created_at DESC")
+            return [dict(r) for r in cursor.fetchall()]
+
+    def list_by_status(self, statuses: list[str]) -> list[dict[str, Any]]:
+        if not statuses:
+            return []
+        # Validate to prevent unknown status values from confusing callers.
+        unknown = set(statuses) - set(_ROOM_VALID_STATUSES)
+        if unknown:
+            raise ValueError(f"Unknown status(es): {sorted(unknown)}")
+        placeholders = ",".join("?" for _ in statuses)
+        with self.db.get_connection() as conn:
+            cursor = conn.execute(
+                f"SELECT * FROM rooms WHERE status IN ({placeholders}) "
+                f"ORDER BY created_at DESC",
+                statuses,
+            )
+            return [dict(r) for r in cursor.fetchall()]
+
+    def assign_operator(self, room_id: str, operator_id: int) -> bool:
+        with self.db.get_connection() as conn:
+            cursor = conn.execute(
+                "UPDATE rooms SET operator_id = ? WHERE id = ?",
+                (operator_id, room_id),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # State transitions
+    # ------------------------------------------------------------------
+    def transition_status(self, room_id: str, target_status: str) -> bool:
+        """Transition the room to target_status.
+
+        Returns False if the room does not exist.
+        Raises InvalidRoomTransition when the target status is unknown
+        OR the source→target edge is not in _ROOM_TRANSITIONS.
+
+        Side effects on success:
+          - status updated
+          - last_activity = CURRENT_TIMESTAMP
+          - closed_at = CURRENT_TIMESTAMP iff target_status == 'closed'
+        """
+        if target_status not in _ROOM_VALID_STATUSES:
+            raise InvalidRoomTransition(f"Unknown room status: {target_status!r}")
+
+        room = self.get_by_id(room_id)
+        if room is None:
+            return False
+
+        current = room["status"]
+        if target_status not in _ROOM_TRANSITIONS.get(current, set()):
+            raise InvalidRoomTransition(
+                f"Invalid transition: {current} → {target_status}"
+            )
+
+        with self.db.get_connection() as conn:
+            if target_status == "closed":
+                conn.execute(
+                    "UPDATE rooms SET status = ?, "
+                    "last_activity = CURRENT_TIMESTAMP, "
+                    "closed_at = CURRENT_TIMESTAMP WHERE id = ?",
+                    (target_status, room_id),
+                )
+            else:
+                conn.execute(
+                    "UPDATE rooms SET status = ?, "
+                    "last_activity = CURRENT_TIMESTAMP WHERE id = ?",
+                    (target_status, room_id),
+                )
+            conn.commit()
+        return True
+
+    def touch(self, room_id: str) -> bool:
+        """Update last_activity = CURRENT_TIMESTAMP. No status change."""
+        with self.db.get_connection() as conn:
+            cursor = conn.execute(
+                "UPDATE rooms SET last_activity = CURRENT_TIMESTAMP WHERE id = ?",
+                (room_id,),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+    def cleanup_stale_rooms(self, now: datetime | None = None) -> list[str]:
+        """Close active/inactive rooms whose last_activity is older than
+        their per-row timeout_minutes.
+
+        Returns the list of room ids that were closed.
+
+        The check is performed in Python (not a single UPDATE) so we can:
+          - Apply per-row timeout_minutes accurately
+          - Run the same transition_status path used by the rest of the
+            code, keeping closed_at + audit semantics consistent
+          - Be unit-testable without monkey-patching SQLite NOW().
+        """
+        now = now or datetime.utcnow()
+        closed_ids: list[str] = []
+        with self.db.get_connection() as conn:
+            cursor = conn.execute(
+                "SELECT id, last_activity, timeout_minutes, status "
+                "FROM rooms WHERE status IN ('active', 'inactive')"
+            )
+            candidates = [dict(r) for r in cursor.fetchall()]
+
+        for room in candidates:
+            last_activity = room.get("last_activity")
+            if not last_activity:
+                # No activity recorded yet — leave alone, will be cleaned
+                # up on the next touch/transition.
+                continue
+            if isinstance(last_activity, str):
+                try:
+                    last_dt = datetime.strptime(last_activity, "%Y-%m-%d %H:%M:%S")
+                except ValueError:
+                    # Unknown timestamp shape; skip rather than crash.
+                    continue
+            elif isinstance(last_activity, datetime):
+                last_dt = last_activity
+            else:
+                continue
+
+            timeout = timedelta(minutes=room["timeout_minutes"])
+            if now - last_dt >= timeout:
+                try:
+                    self.transition_status(room["id"], "closed")
+                    closed_ids.append(room["id"])
+                except InvalidRoomTransition:
+                    # Race: another caller closed it first; skip.
+                    continue
+        return closed_ids
+
+
 def init_admin_from_env(db_manager: DatabaseManager) -> bool:
     """환경변수에서 초기 관리자 계정 생성"""
     admin_username = os.getenv("ADMIN_USERNAME")
@@ -568,6 +836,7 @@ def init_admin_from_env(db_manager: DatabaseManager) -> bool:
 _db_manager = None
 _user_model = None
 _usage_log_model = None
+_room_model = None
 
 
 def get_db_manager() -> DatabaseManager:
@@ -595,3 +864,11 @@ def get_usage_log_model() -> UsageLog:
     if _usage_log_model is None:
         _usage_log_model = UsageLog(get_db_manager())
     return _usage_log_model
+
+
+def get_room_model() -> "Room":
+    """Room 모델 싱글톤 (ISSUE-26)."""
+    global _room_model
+    if _room_model is None:
+        _room_model = Room(get_db_manager())
+    return _room_model

--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -1,145 +1,69 @@
-# Review Notes -- PR #58 (fix(ui): ISSUE-36 viewport height overflow hotfix)
+# Review Notes — ISSUE-26 (PR #60)
 
-**Reviewer**: Claude Opus 4.6 (automated)
-**Date**: 2026-05-06
-**PR Size**: +50 -8 lines across 2 files (both HTML)
-**Test Results**: 322/322 passing (9 viewport-specific tests passing)
-**Confidence Rating**: High -- all changed files reviewed, CSS box model behavior verified analytically, pre-existing tests confirm no regressions.
+**Reviewer**: Claude Opus 4.7 (automated, team-lead REVIEW phase)
+**Date**: 2026-05-07
+**PR Size**: +1055 -12 across 4 files (database.py, room_manager.py, websocket_handler.py, tests/test_rooms_db.py)
 
----
+## Scope
 
-## Summary
+`rooms` 테이블 + `Room` 모델 + `RoomManager` 영속화 + WebSocket auth closed-room 거부.
 
-PR #58 is a hotfix for PR #57 (ISSUE-36), addressing two issues that PR #57's review (CR-1 and CR-2) already identified:
+## Code Review
 
-1. **webrtc.html**: `body { margin: 5% 0 0 0; height: 100% }` caused 105% total height (margin is outside the content box even with `box-sizing: border-box`). Fixed by converting `margin` to `padding`, which stays inside the box with `border-box`.
-2. **scroll_lock.html**: Streamlit injects inline `height: 900px` on wrapper `<div>`s around the iframe (not just the iframe itself). Added CSS selectors and a JS DOM-walking function to override these wrappers to `100vh`.
+### Strengths
 
-Both fixes address real, visible bugs. The approach is correct.
+- **RL-002 컴플라이언스**: `created_by`/`operator_id` 가 users.id FK 로 강제됨 (`PRAGMA foreign_keys=ON`). 클라이언트가 admin/operator 식별자를 위조해도 INSERT 시점에 차단.
+- **RL-006 컴플라이언스**: closed 룸 거부 메시지를 unknown 룸과 동일한 generic 텍스트("요청한 룸을 찾을 수 없습니다.")로 통일. 룸 lifecycle 정보 누설 차단.
+- **RL-005 컴플라이언스**: Room 신규 클래스에 39개 단위 테스트 동반 (CRUD/transition/cleanup/hydrate 모두 커버). 추출 후 테스트 부재 패턴 회피.
+- **State machine 검증 일관성**: `_ROOM_TRANSITIONS` dict + `InvalidRoomTransition` 예외로 다이어그램 위반을 명시적으로 차단. parametrized 테스트로 invalid 경로 5개 (역방향, closed 재활성 등) 모두 검증.
+- **Defense in depth**: 애플리케이션 transition 검증 + DB CHECK 제약 + FK 제약 — 세 단계 방어.
+- **TDD 준수**: tests-written, red phase 체크포인트가 모두 PASS — 테스트 먼저 작성 후 구현.
+- **Idempotency**: `close_room` 은 이미 닫힌 룸 호출 시 raw exception 을 client 로 전달하지 않고 (RL-006), `cleanup_stale_rooms` 는 동시 close 레이스를 `InvalidRoomTransition` catch 로 처리.
 
----
+### Findings
 
-## Findings
+- **CR-1 (Low)** — `Room.cleanup_stale_rooms()` 가 직접 호출되는 경우 (admin tool 등) RoomManager 메모리는 stale 상태로 남는다. 다만 `_authenticate_client` 가 DB 상태를 추가 검증하므로 새로운 연결은 차단되며, 백그라운드 cleanup 루프 (`_periodic_room_cleanup_loop`) 는 `delete_room` 으로 메모리도 동기화한다. **현 사용 패턴에서는 안전.** Follow-up 으로 admin DB 도구가 추가될 때 메모리 동기화 hook 을 도입하는 것을 권장.
 
-### Code Review
+- **CR-2 (Low)** — `transition_status` 가 `active → inactive` 시점에도 `last_activity = CURRENT_TIMESTAMP` 로 갱신한다. 즉 일시정지 직후의 30분이 cleanup 의 시작점이 된다. 이는 spec ("30분간 last_activity 갱신이 없는 비활성 룸") 의 의도이므로 정상 동작.
 
-#### [Low] CR-1: `padding-top: 5%` resolves against width, not height
+- **CR-3 (Nit)** — `Room.create()` 가 INSERT 후 `get_by_id` 로 두 번째 쿼리를 수행. 룸 생성은 저빈도라 무시 가능. 향후 `RETURNING` 절 (SQLite 3.35+) 을 활용해 단일 쿼리로 줄일 수 있음.
 
-- **File**: `components/webrtc.html:20` (`padding: 5% 10px 10px 10px`)
-- **Issue**: In CSS, percentage values for `padding-top` (and `padding-bottom`) resolve against the **width** of the containing block, not the height. This means the top padding will vary with the iframe width, not its height. On a 1920px-wide viewport, `5%` = 96px of top padding. On a 768px-wide viewport, `5%` = ~38px. On a 375px phone, `5%` = ~19px. This is different from the original `margin-top: 5%` which also resolves against the containing block's width (same CSS rule), so the visual spacing is actually preserved.
-- **Blocking**: No. The behavior matches the original intent, and the percentage-of-width rule applies identically to the old `margin-top: 5%`. But developers should be aware this is not "5% of height."
-- **Suggestion**: If the intent is a fixed visual spacing, consider using `padding-top: clamp(16px, 3vh, 48px)` for height-relative spacing. Low priority.
+- **CR-4 (Nit)** — `cleanup_stale_rooms` 의 SELECT 와 `transition_status` UPDATE 가 별도 connection 에서 실행되어 race window 가 존재하지만, `InvalidRoomTransition` catch 로 처리됨. 단일 트랜잭션화는 `transition_status` 의 검증 일관성을 깨므로 비권장.
 
-#### [Low] CR-2: MutationObserver may fire excessively on Streamlit re-renders
+### Test quality
 
-- **File**: `components/scroll_lock.html:131-134`
-- **Issue**: The MutationObserver watches `{ childList: true, subtree: true }` on `.main` (or `document.body` as fallback). `resizeIframeWrappers()` modifies `style` attributes on observed elements. Importantly, the observer only watches `childList` (not `attributes`), so setting `style` on existing elements does NOT trigger re-observation -- this is correct and avoids an infinite loop. However, Streamlit frequently re-renders its DOM (adding/removing child nodes), which will trigger `resizeIframeWrappers()` on every such mutation. The function queries and iterates all iframes and walks up the DOM tree each time.
-- **Blocking**: No. The function is lightweight (a few DOM queries and property sets), and Streamlit mutations are infrequent enough that this will not cause performance issues in practice. The observer correctly limits scope to `childList` only.
-- **Suggestion**: For extra safety, consider debouncing the callback with `requestAnimationFrame` to batch rapid mutations:
-  ```js
-  var pending = false;
-  new MutationObserver(function() {
-      if (!pending) {
-          pending = true;
-          requestAnimationFrame(function() {
-              resizeIframeWrappers();
-              pending = false;
-          });
-      }
-  }).observe(...);
-  ```
+- 39 새 테스트 모두 real assertion 보유 (구체값 비교, 상태 검증, 타입 검증).
+- Schema 검증: `expected = {...}; assert expected.issubset(actual)` 로 컬럼 확장 시 회귀 방어.
+- State transitions: parametrized invalid edges + transition_unknown_room (False return) + transition_unknown_status (raises) 등 negative path 충실.
+- Timeout: stale_inactive, stale_active(zombie), recent (skip), already_closed (skip), per-room timeout (5min override) — 5개 시나리오.
+- Hydrate: active+inactive+waiting 복원 검증, closed 제외, no-repo no-op.
+- WebSocket auth: closed 룸 거부 + 메시지 검사 (`closed`/`exception`/`traceback` 부재 강제).
 
-#### [Low] CR-3: DOM walk terminates correctly but could add a depth guard
+전체 테스트: 381 passed, 14 deselected (e2e), 83.47% coverage. Lint clean.
 
-- **File**: `components/scroll_lock.html:122-127`
-- **Issue**: The `while (el && !el.classList.contains('main'))` loop walks from iframe parent up to `.main`. The two termination conditions are: (1) `el` becomes `null` (reached document root), or (2) `el.classList.contains('main')` (reached the target container). Both are correct. In Streamlit's DOM structure, the `.main` element is typically 3-5 levels above the iframe, so this loop iterates at most ~5 times. There is no risk of infinite loop since `el = el.parentElement` always moves toward the root.
-- **Blocking**: No. The implementation is safe.
-- **Suggestion (optional)**: For defensive coding, a depth limit (e.g., `maxDepth = 20`) could prevent theoretical issues if the DOM structure is unexpectedly deep, but this is not practically necessary.
+## Security Findings
 
-#### [Medium] CR-4: No tests for the new hotfix behaviors
+- **SEC-1 (Info)** — `_authenticate_client` 의 새 DB 상태 체크 분기는 repo 가 raise 하면 fail-closed (room_closed=True) 로 거부한다. DB 장애 시 모든 룸 접속이 막히지만, 잘못 열어주는 것보다 안전하다. 모니터링 권장.
 
-- **File**: N/A (no test files changed)
-- **Issue**: This hotfix changes two behaviors: (1) body uses padding instead of margin, and (2) scroll_lock targets Streamlit wrapper divs. The existing 9 viewport tests still pass, but they test for the presence of `height: 100%` and absence of `90vh` -- they do not verify the margin-to-padding change or the new wrapper selectors. A regression could reintroduce `margin-top` without failing any test.
-- **Blocking**: No, for a hotfix. But tests should be added promptly.
-- **Suggested tests**:
-  ```python
-  def test_body_uses_zero_margin():
-      """body should have margin: 0 (no margin overflow)"""
-      body_css = _get_body_css()
-      assert "margin: 0" in body_css
+- **SEC-2 (Info)** — `_periodic_room_cleanup_loop` 의 sleep interval 은 `ROOM_CLEANUP_INTERVAL_SECONDS` env 로 조정 가능 (기본 60s). 테스트에서 monkey-patch 로 짧게 줄일 수 있어 디버그/스테이징 친화적.
 
-  def test_body_uses_padding_top_for_spacing():
-      """body should use padding (not margin) for top spacing"""
-      body_css = _get_body_css()
-      assert re.search(r"padding:\s*5%", body_css)
+- **SEC-3 (Pass)** — Long-term AWS keys, OpenAI tokens, admin credentials 은 본 변경에 노출되지 않는다.
 
-  def test_scroll_lock_targets_wrapper_divs():
-      """scroll_lock.html should target .stHtml wrapper for height override"""
-      css = _read_scroll_lock()
-      assert ".stHtml" in css
-      assert "element-container" in css
-  ```
+- **SEC-4 (Pass)** — 모든 SQL 은 parameterised. `list_by_status` 의 `IN (?,?,...)` placeholder 도 안전하게 동적 생성.
 
-#### [Info] CR-5: Selector `.stComponentV1` targets `st.components.v1.html`, `.stHtml` targets `st.html`
+## Follow-up suggestions (non-blocking)
 
-- **File**: `components/scroll_lock.html:54-57`
-- **Issue**: The wrapper selectors cover two different Streamlit embedding mechanisms: `.stHtml` / `[data-testid="stHtml"]` (for `st.html()`, which `scroll_lock.html` itself is rendered via `st.markdown`) and `.stComponentV1` / `.element-container` (for `st.components.v1.html()`, which `webrtc.html` is rendered via). Both are needed since `scroll_lock.html` CSS applies to the parent page affecting both its own rendering and the iframe's wrappers.
-- **Blocking**: No. The selectors are correct for the current Streamlit version.
-- **Risk**: Streamlit has a history of renaming internal CSS classes between versions. The `[data-testid="stHtml"]` attribute selector is more stable than the class-based `.stHtml` since Streamlit explicitly maintains `data-testid` for testing. However, `.element-container` and `.stComponentV1` are internal class names that may change. The JS DOM walker (`resizeIframeWrappers`) serves as a robust fallback since it operates on actual DOM structure rather than class names.
+1. `database.py` 에 `last_activity` 인덱스 추가 검토 (cleanup_stale_rooms 의 status 인덱스로 충분하지만, 룸 수 ↑ 시 검토).
+2. `Room` 모델에 `force_close_all_for_user(operator_id)` 같은 admin 도구 helper 가 필요해질 가능성 — ISSUE-29 시 평가.
+3. `_periodic_room_cleanup_loop` 에 prometheus-style 카운터 (closed_count) 노출 고려 — observability 개선.
 
-#### [Info] CR-6: `html` added to `*` selector is redundant but harmless
+## RL-002 / RL-006 / RL-005 / RL-004 verdict
 
-- **File**: `components/webrtc.html:8` (`*, html { box-sizing: border-box; }`)
-- **Issue**: The universal selector `*` already matches all elements including `html`. Adding `, html` to the selector is redundant. This appears to have been done when the `html` rule was added, perhaps to emphasize the intent. It has zero functional impact.
-- **Blocking**: No.
-
----
-
-### Security Findings
-
-No security issues identified.
-
-**Analysis**:
-- The CSS and JS changes are in static HTML files served from the server filesystem. No user input flows into these files.
-- `scroll_lock.html` is injected via `st.markdown(unsafe_allow_html=True)` -- this is a pre-existing pattern where the HTML content is read from a static file on disk, not constructed from user input. The `unsafe_allow_html` flag is necessary for the CSS/JS injection into Streamlit's DOM and is not a vulnerability in this context.
-- The new `resizeIframeWrappers()` JS function only reads DOM structure (`.querySelectorAll`, `.parentElement`, `.classList.contains`) and sets inline styles. It does not process any external input, does not use `innerHTML`, and does not execute dynamic code.
-- The `MutationObserver` only observes DOM tree changes (child additions/removals) and calls the safe `resizeIframeWrappers` function. It does not observe or react to attribute changes from external sources.
-- No new network calls, no new data handling, no credential changes.
-
----
-
-## AC Verification
-
-Based on the problem statement in the PR description:
-
-| Issue | Fixed | How |
-|-------|-------|-----|
-| `margin: 5%` + `height: 100%` = 105% overflow | Yes | Margin converted to padding; with `box-sizing: border-box`, padding stays inside the 100% height |
-| `html` element has no explicit height for `body { height: 100% }` reference | Yes | `html { height: 100%; margin: 0; padding: 0; }` added |
-| Streamlit wrapper divs have inline `height: 900px` | Yes | CSS selectors + JS DOM walker override all wrapper heights to `100vh` |
-| Media queries maintain top spacing | Yes | `padding: 5% 5px 5px 5px` (768px) and `padding: 2% 5px 5px 5px` (600px) updated consistently |
-
----
+- **RL-002 (server-side validation)**: PASS. 클라이언트 입력은 모두 DB 또는 RoomManager 사전 등록과 대조 검증.
+- **RL-006 (error message leakage)**: PASS. 모든 client-facing 에러는 generic. 서버 로그에만 raw exception.
+- **RL-005 (extract-without-tests)**: PASS. 39 새 테스트.
+- **RL-004 (assertion strength)**: PASS. 의미 있는 값 비교, negative path, parametrized invalid edges 포함.
 
 ## Verdict
 
-**APPROVE** -- with suggestions.
-
-The hotfix correctly addresses all three viewport overflow issues identified in the PR description. The CSS box model reasoning is sound: converting `margin-top` to `padding-top` with `box-sizing: border-box` eliminates the 105% overflow, and the Streamlit wrapper height overrides (via both CSS selectors and JS DOM walker) provide a robust dual approach.
-
-**Blocking issues**: None.
-
-**Non-blocking suggestions**:
-- CR-4 (Medium): Add tests for the margin-to-padding change and wrapper selector presence to prevent regressions.
-- CR-2 (Low): Consider debouncing the MutationObserver callback.
-- CR-1 (Low): Be aware that `padding-top: 5%` resolves against width, not height.
-
----
-
-## Follow-ups
-
-1. **[Follow-up] Add regression tests for margin-to-padding fix** -- Add tests verifying `body { margin: 0 }` and `padding-top: 5%` to prevent reintroduction of margin-based spacing. Also test that `scroll_lock.html` contains the wrapper div selectors (`.stHtml`, `.element-container`). Estimated: 15 minutes. (CR-4)
-
-2. **[Follow-up] Debounce MutationObserver callback** -- Wrap `resizeIframeWrappers` in a `requestAnimationFrame` debounce to batch rapid Streamlit DOM mutations. Low priority since the current implementation has no measured performance issue. (CR-2)
-
-3. **[Follow-up] Evaluate Streamlit selector stability** -- Document which Streamlit CSS classes are used and monitor for breakage across Streamlit version upgrades. The `data-testid` attribute selectors are more stable than class-based ones. (CR-5)
+**APPROVED**. 코드 품질, 보안, 테스트 모두 ship 가능한 수준. Critical/High 결함 없음.

--- a/room_manager.py
+++ b/room_manager.py
@@ -1,12 +1,15 @@
 """
-RoomManager 모듈 (ISSUE-25)
+RoomManager 모듈 (ISSUE-25, ISSUE-26)
 
 여러 오퍼레이터가 동시에 독립적인 자막 세션을 운영할 수 있도록
 WebSocket 연결을 룸 단위로 격리한다.
 
 Design notes:
 - 인메모리 dict로 `room_id → RoomState`를 관리한다.
-- DB 영속화는 ISSUE-26에서 다룬다.
+- ISSUE-26: 옵션으로 `room_repository`(database.Room)을 주입받아 룸
+  생성/종료를 DB에 영속화하며, `hydrate_from_db()` 로 서버 재시작 시
+  waiting/active/inactive 룸을 복원한다. 레거시 호출자(테스트, 기본
+  룸)와 호환을 위해 repository 가 None 인 경우 메모리 전용으로 동작한다.
 - 모든 클라이언트-노출 에러 메시지는 generic하게 유지한다 (RL-006).
 - 서버는 client-supplied identity를 신뢰하지 않는다 (RL-002):
   room_id는 RoomManager에 사전 등록된 것만 허용하며 실제 연결 등록은
@@ -60,19 +63,42 @@ class RoomState:
 
 
 class RoomManager:
-    """In-memory registry of active rooms keyed by room_id."""
+    """In-memory registry of active rooms keyed by room_id.
 
-    def __init__(self) -> None:
+    When a `room_repository` (database.Room) is supplied, create_room and
+    close_room also persist to DB and hydrate_from_db() restores rooms
+    on server start (ISSUE-26).
+    """
+
+    def __init__(self, room_repository: Any | None = None) -> None:
         self._rooms: dict[str, RoomState] = {}
+        # database.Room | None  — optional persistence layer.
+        # Typed as Any to avoid an import cycle with database.py.
+        self._repo = room_repository
 
     # ------------------------------------------------------------------
     # CRUD
     # ------------------------------------------------------------------
-    def create_room(self, room_id: str | None = None) -> RoomState:
+    def create_room(
+        self,
+        room_id: str | None = None,
+        *,
+        name: str | None = None,
+        created_by: int | None = None,
+        input_lang: str = "auto",
+        output_lang: str = "ko",
+        timeout_minutes: int = 30,
+    ) -> RoomState:
         """Create a new room. Generates a unique id when none supplied.
 
+        When a repository is attached, the room is persisted with the
+        supplied `name`/`created_by`. Without a repository these fields
+        are ignored (legacy in-memory mode for tests + the default room).
+
         Raises:
-            ValueError: if the supplied room_id already exists.
+            ValueError: if the supplied room_id already exists in memory.
+            ValueError: if persistence is requested but `name` or
+                `created_by` is missing.
         """
         if room_id is None:
             # Generate a unique id; retry on the (vanishingly rare) collision.
@@ -87,7 +113,33 @@ class RoomManager:
         if room_id in self._rooms:
             raise ValueError(f"Room id already exists: {room_id}")
 
+        if self._repo is not None:
+            # Persist first so that we never put a room into memory that
+            # is not durable. Required fields enforced here so the caller
+            # gets a clear error rather than a deferred IntegrityError.
+            if name is None or created_by is None:
+                raise ValueError(
+                    "create_room with persistence requires `name` and `created_by`"
+                )
+            persisted = self._repo.create(
+                room_id=room_id,
+                name=name,
+                created_by=created_by,
+                input_lang=input_lang,
+                output_lang=output_lang,
+                timeout_minutes=timeout_minutes,
+            )
+            if persisted is None:
+                # PK collision in DB but not in memory — extremely rare,
+                # surfaces as ValueError to match the in-memory branch.
+                raise ValueError(f"Room id already exists: {room_id}")
+
         state = RoomState(room_id=room_id)
+        if name is not None:
+            state.language_settings = {
+                "input_lang": input_lang,
+                "output_lang": output_lang,
+            }
         self._rooms[room_id] = state
         return state
 
@@ -99,7 +151,9 @@ class RoomManager:
         """Return the room for room_id, creating it if missing.
 
         Used for the default-room fallback so that a brand-new server
-        accepts connections without explicit room provisioning.
+        accepts connections without explicit room provisioning. This
+        path NEVER touches the repository — the default room is an
+        in-memory convenience and not a managed conference room.
         """
         room = self._rooms.get(room_id)
         if room is None:
@@ -108,12 +162,74 @@ class RoomManager:
         return room
 
     def delete_room(self, room_id: str) -> bool:
-        """Remove a room. Returns True if it existed, False otherwise."""
+        """Remove a room from memory. Returns True if it existed.
+
+        This is the legacy in-memory-only operation kept for the
+        default room and unit tests. For the managed-room lifecycle
+        use `close_room()` which also persists the closed status.
+        """
         return self._rooms.pop(room_id, None) is not None
+
+    def close_room(self, room_id: str) -> bool:
+        """Transition the room to 'closed' (DB) and remove from memory.
+
+        Idempotent: returns False if the room is unknown both in memory
+        and in the repository.
+        """
+        existed = self._rooms.pop(room_id, None) is not None
+        if self._repo is not None:
+            try:
+                # transition_status returns False for unknown rooms and
+                # raises InvalidRoomTransition only for impossible edges
+                # (e.g. closed → closed). Closed→closed is idempotent.
+                self._repo.transition_status(room_id, "closed")
+            except Exception as e:  # InvalidRoomTransition or DB error
+                # Already-closed rooms hit this branch; treat as success.
+                if existed:
+                    return True
+                # Otherwise, surface as a no-op false but keep the
+                # exception detail server-side (RL-006: never propagate
+                # raw text to clients; this is a server-side print).
+                print(f"[Room] close_room: ignoring repo error: {e!r}")
+        return existed
 
     def list_rooms(self) -> list[str]:
         """Snapshot of registered room ids."""
         return list(self._rooms.keys())
+
+    # ------------------------------------------------------------------
+    # Persistence integration (ISSUE-26)
+    # ------------------------------------------------------------------
+    def hydrate_from_db(self) -> int:
+        """Re-load DB rooms with hydratable status into memory.
+
+        Called once at server start so that operators can resume sessions
+        after a restart without manual intervention. Closed rooms are
+        terminal and intentionally NOT hydrated.
+
+        Returns the number of rooms loaded. No-op if repository missing.
+        """
+        if self._repo is None:
+            return 0
+        loaded = 0
+        # Source of truth — Room.HYDRATABLE_STATUSES.
+        statuses = list(
+            getattr(
+                self._repo, "HYDRATABLE_STATUSES", ("waiting", "active", "inactive")
+            )
+        )
+        for row in self._repo.list_by_status(statuses):
+            rid = row["id"]
+            if rid in self._rooms:
+                continue
+            state = RoomState(room_id=rid)
+            state.language_settings = {
+                "input_lang": row.get("input_lang") or "auto",
+                "output_lang": row.get("output_lang") or "ko",
+            }
+            self._rooms[rid] = state
+            loaded += 1
+        return loaded
 
     # ------------------------------------------------------------------
     # Connection registration

--- a/tests/test_rooms_db.py
+++ b/tests/test_rooms_db.py
@@ -1,0 +1,579 @@
+"""
+rooms 테이블 및 Room 모델 단위 테스트 (ISSUE-26)
+
+검증 대상:
+- rooms 테이블이 init_database()에서 생성된다
+- Room CRUD (생성/조회/목록/삭제)
+- 상태 전이 (waiting → active → inactive → active/closed, 강제 종료)
+- 잘못된 전이 거부
+- 타임아웃 정리 (last_activity 30분 이상 미갱신 → closed)
+- 외래 키 무결성 (foreign_keys=ON, created_by 필수)
+- 서버 재시작 복원 (RoomManager.hydrate_from_db)
+- WebSocket 인증 시 closed 룸 거부 (RL-006: 일반화된 에러 메시지)
+
+Note: SQLite tmp_path 기반 격리. 외부 I/O 없음.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+import time
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# websocket_handler -> auth -> streamlit 의존성 mock
+if "streamlit" not in sys.modules:
+    sys.modules["streamlit"] = MagicMock()
+if "extra_streamlit_components" not in sys.modules:
+    sys.modules["extra_streamlit_components"] = MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "rooms.db")
+
+
+@pytest.fixture
+def db_manager(db_path):
+    from database import DatabaseManager
+
+    return DatabaseManager(db_path)
+
+
+@pytest.fixture
+def admin_user_id(db_manager):
+    """rooms.created_by FK 를 만족시키기 위한 관리자 사용자."""
+    from database import User
+
+    user_model = User(db_manager)
+    return user_model.create_user(
+        username="admin1",
+        password="pw",
+        role="admin",
+        usage_limit_seconds=0,
+    )
+
+
+@pytest.fixture
+def operator_user_id(db_manager):
+    from database import User
+
+    user_model = User(db_manager)
+    return user_model.create_user(
+        username="op1",
+        password="pw",
+        role="user",
+        usage_limit_seconds=3600,
+    )
+
+
+@pytest.fixture
+def room_model(db_manager):
+    from database import Room
+
+    return Room(db_manager)
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+class TestRoomsSchema:
+    """AC: rooms 테이블이 init_database()에서 생성된다."""
+
+    def test_rooms_table_exists(self, db_manager):
+        with db_manager.get_connection() as conn:
+            cur = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='rooms'"
+            )
+            assert cur.fetchone() is not None
+
+    def test_rooms_columns(self, db_manager):
+        """기대 컬럼 셋이 모두 존재한다."""
+        expected = {
+            "id",
+            "name",
+            "status",
+            "input_lang",
+            "output_lang",
+            "created_by",
+            "operator_id",
+            "created_at",
+            "last_activity",
+            "timeout_minutes",
+            "closed_at",
+        }
+        with db_manager.get_connection() as conn:
+            cur = conn.execute("PRAGMA table_info(rooms)")
+            actual = {row["name"] for row in cur.fetchall()}
+        assert expected.issubset(actual), f"missing: {expected - actual}"
+
+    def test_rooms_id_is_text_primary_key(self, db_manager):
+        with db_manager.get_connection() as conn:
+            cur = conn.execute("PRAGMA table_info(rooms)")
+            cols = {row["name"]: dict(row) for row in cur.fetchall()}
+        assert cols["id"]["pk"] == 1
+        assert cols["id"]["type"].upper() == "TEXT"
+
+    def test_default_values(self, db_manager, admin_user_id):
+        """status, input_lang, output_lang, timeout_minutes 기본값."""
+        with db_manager.get_connection() as conn:
+            conn.execute(
+                "INSERT INTO rooms (id, name, created_by) VALUES (?, ?, ?)",
+                ("r1", "A홀", admin_user_id),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT status, input_lang, output_lang, timeout_minutes "
+                "FROM rooms WHERE id=?",
+                ("r1",),
+            ).fetchone()
+        assert row["status"] == "waiting"
+        assert row["input_lang"] == "auto"
+        assert row["output_lang"] == "ko"
+        assert row["timeout_minutes"] == 30
+
+
+class TestRoomsForeignKeys:
+    """FK 제약: created_by, operator_id → users.id (PRAGMA foreign_keys=ON)."""
+
+    def test_created_by_fk_rejects_invalid_user(self, db_manager):
+        with db_manager.get_connection() as conn, pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO rooms (id, name, created_by) VALUES (?, ?, ?)",
+                ("r-bad", "X", 99999),
+            )
+            conn.commit()
+
+    def test_operator_id_fk_rejects_invalid_user(self, db_manager, admin_user_id):
+        with db_manager.get_connection() as conn, pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO rooms (id, name, created_by, operator_id) "
+                "VALUES (?, ?, ?, ?)",
+                ("r-bad-op", "X", admin_user_id, 99999),
+            )
+            conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Room CRUD
+# ---------------------------------------------------------------------------
+class TestRoomCrud:
+    """AC: Room CRUD."""
+
+    def test_create_returns_row(self, room_model, admin_user_id):
+        room = room_model.create(
+            room_id="r-1",
+            name="A홀 기조연설",
+            created_by=admin_user_id,
+        )
+        assert room is not None
+        assert room["id"] == "r-1"
+        assert room["name"] == "A홀 기조연설"
+        assert room["status"] == "waiting"
+        assert room["created_by"] == admin_user_id
+
+    def test_create_with_custom_lang_and_timeout(self, room_model, admin_user_id):
+        room = room_model.create(
+            room_id="r-2",
+            name="B홀",
+            created_by=admin_user_id,
+            input_lang="en",
+            output_lang="ko",
+            timeout_minutes=10,
+        )
+        assert room["input_lang"] == "en"
+        assert room["output_lang"] == "ko"
+        assert room["timeout_minutes"] == 10
+
+    def test_create_duplicate_id_returns_none(self, room_model, admin_user_id):
+        room_model.create(room_id="r-dup", name="X", created_by=admin_user_id)
+        # IntegrityError on PK collision is mapped to None (mirrors User.create_user)
+        result = room_model.create(room_id="r-dup", name="Y", created_by=admin_user_id)
+        assert result is None
+
+    def test_get_by_id_returns_room(self, room_model, admin_user_id):
+        room_model.create(room_id="r-3", name="C", created_by=admin_user_id)
+        room = room_model.get_by_id("r-3")
+        assert room is not None
+        assert room["id"] == "r-3"
+
+    def test_get_by_id_unknown_returns_none(self, room_model):
+        assert room_model.get_by_id("nope") is None
+
+    def test_list_rooms_returns_all(self, room_model, admin_user_id):
+        room_model.create(room_id="r-a", name="A", created_by=admin_user_id)
+        room_model.create(room_id="r-b", name="B", created_by=admin_user_id)
+        ids = {r["id"] for r in room_model.list_all()}
+        assert {"r-a", "r-b"}.issubset(ids)
+
+    def test_list_by_status(self, room_model, admin_user_id):
+        room_model.create(room_id="r-w1", name="W1", created_by=admin_user_id)
+        room_model.create(room_id="r-w2", name="W2", created_by=admin_user_id)
+        room_model.transition_status("r-w1", "active")
+        active = room_model.list_by_status(["active"])
+        ids = {r["id"] for r in active}
+        assert "r-w1" in ids
+        assert "r-w2" not in ids
+
+    def test_assign_operator(self, room_model, admin_user_id, operator_user_id):
+        room_model.create(room_id="r-op", name="OpRoom", created_by=admin_user_id)
+        ok = room_model.assign_operator("r-op", operator_user_id)
+        assert ok is True
+        room = room_model.get_by_id("r-op")
+        assert room["operator_id"] == operator_user_id
+
+
+# ---------------------------------------------------------------------------
+# State transitions
+# ---------------------------------------------------------------------------
+class TestRoomStateTransitions:
+    """AC: 상태 전이가 다이어그램대로 동작한다.
+
+    waiting → active     (오퍼레이터가 시작)
+    active → inactive    (오퍼레이터가 정지)
+    inactive → active    (오퍼레이터가 재시작)
+    inactive → closed    (타임아웃 또는 관리자 종료)
+    active → closed      (관리자 강제 종료)
+    waiting → closed     (관리자 삭제)
+    """
+
+    @pytest.fixture
+    def room_id(self, room_model, admin_user_id):
+        room_model.create(room_id="r-trans", name="T", created_by=admin_user_id)
+        return "r-trans"
+
+    def test_waiting_to_active(self, room_model, room_id):
+        ok = room_model.transition_status(room_id, "active")
+        assert ok is True
+        assert room_model.get_by_id(room_id)["status"] == "active"
+
+    def test_active_to_inactive(self, room_model, room_id):
+        room_model.transition_status(room_id, "active")
+        ok = room_model.transition_status(room_id, "inactive")
+        assert ok is True
+        assert room_model.get_by_id(room_id)["status"] == "inactive"
+
+    def test_inactive_to_active(self, room_model, room_id):
+        room_model.transition_status(room_id, "active")
+        room_model.transition_status(room_id, "inactive")
+        ok = room_model.transition_status(room_id, "active")
+        assert ok is True
+        assert room_model.get_by_id(room_id)["status"] == "active"
+
+    def test_inactive_to_closed_sets_closed_at(self, room_model, room_id):
+        room_model.transition_status(room_id, "active")
+        room_model.transition_status(room_id, "inactive")
+        ok = room_model.transition_status(room_id, "closed")
+        assert ok is True
+        room = room_model.get_by_id(room_id)
+        assert room["status"] == "closed"
+        assert room["closed_at"] is not None
+
+    def test_active_to_closed(self, room_model, room_id):
+        room_model.transition_status(room_id, "active")
+        ok = room_model.transition_status(room_id, "closed")
+        assert ok is True
+        assert room_model.get_by_id(room_id)["status"] == "closed"
+
+    def test_waiting_to_closed(self, room_model, room_id):
+        ok = room_model.transition_status(room_id, "closed")
+        assert ok is True
+        assert room_model.get_by_id(room_id)["status"] == "closed"
+
+    @pytest.mark.parametrize(
+        "src,dst",
+        [
+            ("waiting", "inactive"),  # 비허용
+            ("closed", "active"),  # 종료된 룸 재활성 금지
+            ("closed", "inactive"),
+            ("closed", "waiting"),
+            ("active", "waiting"),  # 역방향 금지
+        ],
+    )
+    def test_invalid_transitions_rejected(self, room_model, room_id, src, dst):
+        from database import InvalidRoomTransition
+
+        # Force room into 'src' state by walking valid transitions first
+        if src == "active":
+            room_model.transition_status(room_id, "active")
+        elif src == "closed":
+            room_model.transition_status(room_id, "closed")
+        # waiting is the default
+        with pytest.raises(InvalidRoomTransition):
+            room_model.transition_status(room_id, dst)
+
+    def test_transition_unknown_room_returns_false(self, room_model):
+        assert room_model.transition_status("ghost", "active") is False
+
+    def test_transition_unknown_target_status_raises(self, room_model, room_id):
+        from database import InvalidRoomTransition
+
+        with pytest.raises(InvalidRoomTransition):
+            room_model.transition_status(room_id, "exploded")
+
+    def test_touch_updates_last_activity(self, room_model, room_id):
+        room_model.transition_status(room_id, "active")
+        before = room_model.get_by_id(room_id)["last_activity"]
+        # Force a measurable delta even if SQLite resolution is 1s
+        time.sleep(1.05)
+        room_model.touch(room_id)
+        after = room_model.get_by_id(room_id)["last_activity"]
+        assert before is None or after >= before
+        assert after is not None
+
+
+# ---------------------------------------------------------------------------
+# Timeout cleanup
+# ---------------------------------------------------------------------------
+class TestRoomTimeoutCleanup:
+    """AC: 30분간 last_activity 미갱신 비활성 룸이 자동으로 closed 처리된다."""
+
+    def _backdate_last_activity(self, db_manager, room_id, minutes_ago):
+        ts = (datetime.utcnow() - timedelta(minutes=minutes_ago)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        with db_manager.get_connection() as conn:
+            conn.execute(
+                "UPDATE rooms SET last_activity = ? WHERE id = ?",
+                (ts, room_id),
+            )
+            conn.commit()
+
+    def test_cleanup_closes_inactive_room_past_timeout(
+        self, room_model, db_manager, admin_user_id
+    ):
+        room_model.create(
+            room_id="r-stale",
+            name="stale",
+            created_by=admin_user_id,
+            timeout_minutes=30,
+        )
+        room_model.transition_status("r-stale", "active")
+        room_model.transition_status("r-stale", "inactive")
+        self._backdate_last_activity(db_manager, "r-stale", 60)
+
+        closed = room_model.cleanup_stale_rooms()
+        assert "r-stale" in closed
+        assert room_model.get_by_id("r-stale")["status"] == "closed"
+
+    def test_cleanup_closes_active_room_past_timeout(
+        self, room_model, db_manager, admin_user_id
+    ):
+        """Active 룸도 last_activity가 timeout 초과면 closed (좀비 정리)."""
+        room_model.create(
+            room_id="r-zombie",
+            name="zombie",
+            created_by=admin_user_id,
+            timeout_minutes=30,
+        )
+        room_model.transition_status("r-zombie", "active")
+        self._backdate_last_activity(db_manager, "r-zombie", 90)
+
+        closed = room_model.cleanup_stale_rooms()
+        assert "r-zombie" in closed
+        assert room_model.get_by_id("r-zombie")["status"] == "closed"
+
+    def test_cleanup_skips_recent_rooms(self, room_model, db_manager, admin_user_id):
+        room_model.create(
+            room_id="r-fresh",
+            name="fresh",
+            created_by=admin_user_id,
+            timeout_minutes=30,
+        )
+        room_model.transition_status("r-fresh", "active")
+        # last_activity = now, well within timeout
+        closed = room_model.cleanup_stale_rooms()
+        assert "r-fresh" not in closed
+        assert room_model.get_by_id("r-fresh")["status"] == "active"
+
+    def test_cleanup_skips_already_closed(self, room_model, db_manager, admin_user_id):
+        room_model.create(room_id="r-done", name="done", created_by=admin_user_id)
+        room_model.transition_status("r-done", "closed")
+        self._backdate_last_activity(db_manager, "r-done", 999)
+        closed = room_model.cleanup_stale_rooms()
+        assert "r-done" not in closed
+
+    def test_cleanup_respects_per_room_timeout(
+        self, room_model, db_manager, admin_user_id
+    ):
+        """timeout_minutes=5 인 룸이 10분 stale 이면 정리된다."""
+        room_model.create(
+            room_id="r-short",
+            name="short",
+            created_by=admin_user_id,
+            timeout_minutes=5,
+        )
+        room_model.transition_status("r-short", "active")
+        self._backdate_last_activity(db_manager, "r-short", 10)
+        closed = room_model.cleanup_stale_rooms()
+        assert "r-short" in closed
+
+
+# ---------------------------------------------------------------------------
+# Server-restart restore
+# ---------------------------------------------------------------------------
+class TestRoomManagerHydrate:
+    """AC: 서버 재시작 시 DB의 active/inactive 룸이 RoomManager에 복원된다."""
+
+    def test_hydrate_loads_active_and_inactive(
+        self, db_manager, room_model, admin_user_id
+    ):
+        from room_manager import RoomManager
+
+        room_model.create(room_id="r-act", name="A", created_by=admin_user_id)
+        room_model.transition_status("r-act", "active")
+        room_model.create(room_id="r-ina", name="I", created_by=admin_user_id)
+        room_model.transition_status("r-ina", "active")
+        room_model.transition_status("r-ina", "inactive")
+        room_model.create(room_id="r-cld", name="C", created_by=admin_user_id)
+        room_model.transition_status("r-cld", "closed")
+        # waiting room SHOULD also be restored so admins can launch them
+        room_model.create(room_id="r-wait", name="W", created_by=admin_user_id)
+
+        rm = RoomManager(room_repository=room_model)
+        rm.hydrate_from_db()
+
+        ids = set(rm.list_rooms())
+        assert "r-act" in ids
+        assert "r-ina" in ids
+        assert "r-wait" in ids
+        # closed rooms must NOT be hydrated
+        assert "r-cld" not in ids
+
+    def test_hydrate_with_no_repo_is_noop(self):
+        from room_manager import RoomManager
+
+        rm = RoomManager()  # no repo
+        # should not raise
+        rm.hydrate_from_db()
+        assert rm.list_rooms() == []
+
+
+# ---------------------------------------------------------------------------
+# RoomManager DB integration
+# ---------------------------------------------------------------------------
+class TestRoomManagerPersistence:
+    """RoomManager가 create/close 시 DB에 영속화한다."""
+
+    def test_create_room_persists_when_repo_attached(
+        self, db_manager, room_model, admin_user_id
+    ):
+        from room_manager import RoomManager
+
+        rm = RoomManager(room_repository=room_model)
+        rm.create_room(
+            room_id="r-persist",
+            name="Persist",
+            created_by=admin_user_id,
+        )
+        # In-memory
+        assert rm.get_room("r-persist") is not None
+        # Persisted
+        row = room_model.get_by_id("r-persist")
+        assert row is not None
+        assert row["name"] == "Persist"
+        assert row["created_by"] == admin_user_id
+
+    def test_close_room_persists_status(self, db_manager, room_model, admin_user_id):
+        from room_manager import RoomManager
+
+        rm = RoomManager(room_repository=room_model)
+        rm.create_room(room_id="r-close", name="X", created_by=admin_user_id)
+        rm.close_room("r-close")
+        # In-memory removal (no longer accepting connections)
+        assert rm.get_room("r-close") is None
+        # DB shows closed
+        row = room_model.get_by_id("r-close")
+        assert row["status"] == "closed"
+        assert row["closed_at"] is not None
+
+    def test_create_room_without_repo_still_in_memory(self):
+        """No regression: legacy callers without DB repo still work."""
+        from room_manager import RoomManager
+
+        rm = RoomManager()
+        room = rm.create_room()
+        assert rm.get_room(room.room_id) is room
+
+
+# ---------------------------------------------------------------------------
+# WebSocket auth: closed-room rejection (RL-006)
+# ---------------------------------------------------------------------------
+class TestWebSocketAuthClosedRoom:
+    """AC: closed 상태의 룸은 WebSocket 접속이 거부된다 (generic message)."""
+
+    def _make_websocket(self, msg):
+        ws = AsyncMock()
+        ws.recv = AsyncMock(return_value=json.dumps(msg))
+        ws.send = AsyncMock()
+        return ws
+
+    def _sent(self, ws):
+        return [json.loads(c.args[0]) for c in ws.send.call_args_list]
+
+    def test_closed_room_auth_rejected_with_generic_message(
+        self, db_manager, room_model, admin_user_id
+    ):
+        """RL-002 (DB 검증) + RL-006 (메시지 누설 금지)."""
+        import websocket_handler
+        from database import User
+        from room_manager import RoomManager
+
+        # Create a real validated user
+        user_model = User(db_manager)
+        user_model.create_user(
+            username="op-ws",
+            password="pw",
+            role="user",
+            usage_limit_seconds=3600,
+        )
+        user_row = user_model.get_user_by_username("op-ws")
+
+        # Create a room and close it (simulating room shut down)
+        rm = RoomManager(room_repository=room_model)
+        rm.create_room(
+            room_id="r-closed-ws",
+            name="X",
+            created_by=admin_user_id,
+        )
+        rm.close_room("r-closed-ws")
+
+        ws = self._make_websocket(
+            {
+                "type": "auth",
+                "user": {
+                    "id": user_row["id"],
+                    "username": "op-ws",
+                    "role": "user",
+                },
+                "room_id": "r-closed-ws",
+            }
+        )
+
+        with (
+            patch.object(websocket_handler, "_room_manager", rm),
+            patch("websocket_handler.get_user_model", return_value=user_model),
+        ):
+            result = asyncio.run(websocket_handler._authenticate_client(ws))
+
+        assert result is None
+        sent = self._sent(ws)
+        # No auth_success sent
+        assert all(m.get("type") != "auth_success" for m in sent)
+        # Generic error (RL-006: must NOT reveal "closed" or stack details)
+        errors = [m for m in sent if m.get("type") == "auth_error"]
+        assert errors, "expected at least one auth_error"
+        for err in errors:
+            msg = err.get("message", "")
+            # Must be generic — no internal status leak
+            assert "closed" not in msg.lower()
+            assert "exception" not in msg.lower()
+            assert "traceback" not in msg.lower()

--- a/websocket_handler.py
+++ b/websocket_handler.py
@@ -146,9 +146,26 @@ async def _authenticate_client(websocket):
             room_manager = _room_manager
             if requested_room_id:
                 room = room_manager.get_room(requested_room_id)
-                if room is None:
+                # ISSUE-26: even if memory still holds the room (e.g.
+                # cleanup_stale_rooms updated DB only), reject when the
+                # persisted status is 'closed'. We share the same
+                # generic message used for unknown rooms (RL-006) to
+                # avoid leaking lifecycle information to clients.
+                room_closed = False
+                repo = getattr(room_manager, "_repo", None)
+                if repo is not None:
+                    try:
+                        persisted = repo.get_by_id(requested_room_id)
+                        if persisted is None or persisted["status"] == "closed":
+                            room_closed = True
+                    except Exception as e:
+                        # Server-side log only (RL-006). Treat repo
+                        # errors as fail-open=False — refuse the room.
+                        print(f"[Auth] 룸 상태 조회 실패: {e!r}")
+                        room_closed = True
+                if room is None or room_closed:
                     print(
-                        f"[Auth] 인증 실패: 존재하지 않는 룸 ID "
+                        f"[Auth] 인증 실패: 룸 사용 불가 "
                         f"(user={validated_user['username']})"
                     )
                     await websocket.send(
@@ -633,6 +650,36 @@ async def handle_openai_websocket(websocket):
         print("[WebSocket] 클라이언트 연결 종료")
 
 
+# Interval (seconds) between stale-room scans. Override via env var
+# for tests / staging. Default 60s gives O(timeout_minutes) latency
+# for closing zombie rooms without spamming the DB.
+ROOM_CLEANUP_INTERVAL_SECONDS = int(os.getenv("ROOM_CLEANUP_INTERVAL_SECONDS", "60"))
+
+
+async def _periodic_room_cleanup_loop() -> None:
+    """Run Room.cleanup_stale_rooms() at a fixed interval.
+
+    Errors are logged and swallowed so the loop never dies silently.
+    Cancellation (server shutdown) is propagated cleanly.
+    """
+    while True:
+        try:
+            await asyncio.sleep(ROOM_CLEANUP_INTERVAL_SECONDS)
+            repo = getattr(_room_manager, "_repo", None)
+            if repo is None:
+                continue
+            closed = repo.cleanup_stale_rooms()
+            if closed:
+                # Sync memory: drop closed rooms so future auths fail.
+                for rid in closed:
+                    _room_manager.delete_room(rid)
+                print(f"[Room] 좀비 룸 정리: {len(closed)}개 closed")
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            print(f"[Room] cleanup loop error: {e!r}")
+
+
 def start_websocket_server(port_ref):
     """WebSocket 서버 시작 (동적 포트 할당)
 
@@ -643,6 +690,24 @@ def start_websocket_server(port_ref):
         free_port = find_free_port()
         print(f"[WebSocket] 할당된 포트: {free_port}")
         port_ref["port"] = free_port
+
+        # ISSUE-26: attach the persistent Room repository, hydrate
+        # waiting/active/inactive rooms from DB, and start the periodic
+        # stale-room cleanup. Best-effort: any failure here only
+        # downgrades to in-memory mode — server continues to start.
+        try:
+            from database import get_room_model
+
+            global _room_manager
+            repo = get_room_model()
+            _room_manager = RoomManager(room_repository=repo)
+            loaded = _room_manager.hydrate_from_db()
+            if loaded:
+                print(f"[Room] DB 복원: {loaded}개 룸")
+        except Exception as e:
+            # Fall back to in-memory mode; never block server start
+            # on persistence wiring.
+            print(f"[Room] 영속 저장소 연결 실패 — 메모리 전용 모드: {e!r}")
 
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
@@ -658,7 +723,13 @@ def start_websocket_server(port_ref):
                     f"[WebSocket] 서버 시작 완료 (OpenAI 모드): "
                     f"ws://0.0.0.0:{free_port}"
                 )
-                await server.wait_closed()
+                # Background task: scan for stale rooms every minute and
+                # close them. Cancelled when wait_closed returns.
+                cleanup_task = asyncio.create_task(_periodic_room_cleanup_loop())
+                try:
+                    await server.wait_closed()
+                finally:
+                    cleanup_task.cancel()
             except Exception as e:
                 print(f"[WebSocket] 서버 실행 오류: {e}")
                 raise e


### PR DESCRIPTION
Closes #44

## Summary

ISSUE-26 — 룸 정보를 DB에 영속화하고, 상태 전이(생성→활성→비활성→종료) 및 타임아웃 기반 자동 정리를 구현했습니다.

## What changed

### `database.py`
- **`rooms` 테이블 추가** (`init_database()`): TEXT PK `id`, `name`, `status` (`waiting|active|inactive|closed` CHECK 제약), `input_lang`/`output_lang`, `created_by`/`operator_id` (FK → users.id), `created_at`/`last_activity`/`closed_at`, `timeout_minutes` (default 30).
- 인덱스: `idx_rooms_status` — cleanup, list_by_status, hydrate 핫 패스.
- **`Room` 클래스**: `create()`, `get_by_id()`, `list_all()`, `list_by_status()`, `assign_operator()`, `transition_status()`, `touch()`, `cleanup_stale_rooms()`.
- **`InvalidRoomTransition` 예외**: 잘못된 상태 전이를 명확히 차단 (다이어그램 위반시 raise).
- **`get_room_model()` 싱글톤** 추가 (legacy User/UsageLog 패턴 따름).

### `room_manager.py` (ISSUE-25에서 확장)
- 옵셔널 `room_repository` 주입 (`RoomManager(room_repository=...)`). 미주입 시 메모리 전용 모드(기존 호환).
- `create_room(...)`: repository 주입 시 DB에 영속화 (`name`, `created_by` 필수).
- `close_room(room_id)`: 메모리에서 제거 + DB 상태 `closed`로 전이 (idempotent).
- `hydrate_from_db()`: 서버 재시작 시 `waiting/active/inactive` 룸을 메모리에 복원. `closed`는 복원하지 않음 (terminal).

### `websocket_handler.py`
- `_authenticate_client`: closed 룸 거부 (메모리 + DB 두 단계 체크). 메시지는 unknown 룸과 동일한 generic 텍스트로 통일하여 lifecycle 정보 누설 방지 (RL-006).
- `start_websocket_server`: 부팅 시 `RoomManager`를 `Room` repository와 함께 재구성하고 `hydrate_from_db()` 실행. 실패 시 메모리 모드로 폴백 (서버 시작은 절대 막지 않음).
- 백그라운드 태스크 `_periodic_room_cleanup_loop()` (기본 60초 주기, `ROOM_CLEANUP_INTERVAL_SECONDS` env로 조정 가능): `cleanup_stale_rooms()` 호출 후 닫힌 룸을 메모리에서도 동기화.

### Tests (`tests/test_rooms_db.py`, 39 cases)
- Schema/FK: 테이블 컬럼 셋, TEXT PK, 기본값, FK 위반 거부.
- CRUD: 생성/조회/목록/상태별 필터/오퍼레이터 배정.
- State transitions: 6개 valid 경로 + parametrized invalid 경로(역방향, closed 재활성, waiting→inactive 등) + 알 수 없는 status raises.
- Timeout cleanup: stale inactive/active 둘 다 closed, fresh 룸은 보존, closed는 idempotent skip, per-room timeout 적용.
- Hydrate: active+inactive+waiting 복원, closed 제외, repo 미주입 시 no-op.
- WebSocket auth: closed 룸은 generic 메시지로 거부 (RL-006 — "closed", "exception", "traceback" 누설 금지 검증).

## Acceptance criteria status

- [x] `rooms` 테이블이 `init_database()`에서 생성된다
- [x] 룸 상태 전이가 다이어그램대로 동작한다
- [x] 30분간 `last_activity` 미갱신 비활성 룸이 자동으로 `closed` 처리된다
- [x] 서버 재시작 시 DB의 `waiting/active/inactive` 룸이 RoomManager에 복원된다
- [x] `closed` 상태의 룸은 WebSocket 접속이 거부된다 (RL-006 generic 메시지)

## Test plan

- [x] `uv run pytest -q` — 381 passed, 14 deselected (e2e), 83% coverage
- [x] `uv run ruff check .` — 0 errors
- [x] `uv run black --check ...` — 변경 파일 모두 통과
- [x] `uv run pytest -q -k room --no-cov` — 64 passed (rooms_db + room_manager)

## Rollback

`rooms` 테이블 DROP, `RoomManager.__init__`에서 `room_repository` 인자 제거, `_periodic_room_cleanup_loop`/`hydrate_from_db` 호출 제거.

## Review focus

- RL-002: 클라이언트가 `closed` 룸의 status를 추측 가능한지 (메시지 일치 확인)
- RL-006: cleanup loop의 print가 raw exception을 클라이언트로 전달하지 않는지
- RL-005: 추출/리팩터링 동반 테스트 커버리지 (Room 신규 클래스 39 케이스 추가)
- Race conditions: `close_room` idempotency, `cleanup_stale_rooms` ↔ `transition_status` 간 충돌 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)