### PR TITLE
[ISSUE-27] feat(ui): 오퍼레이터 사이드바 — 배정된 룸 시작/정지

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@
 - translation.py: 번역 서비스
 - services.py: OpenAI/AWS 세션 관리
 - websocket_handler.py: WebSocket 서버/핸들러
+- operator_ui.py: 사이드바 룸 선택 순수 로직 (ISSUE-27)
 """
 
 import asyncio
@@ -20,6 +21,13 @@ from auth import (
     get_current_user,
     init_session_state,
     is_authenticated,
+)
+from database import get_room_model
+from operator_ui import (
+    build_bootstrap_payload,
+    build_room_dropdown_options,
+    has_assigned_rooms,
+    select_default_room,
 )
 from services import (
     create_openai_session,
@@ -70,6 +78,24 @@ try:
 except FileNotFoundError:
     pass
 
+
+def _load_assigned_rooms_for_user(user):
+    """배정된 룸 목록을 안전하게 조회한다 (ISSUE-27).
+
+    - admin은 룸 배정 개념이 없으므로 빈 리스트로 처리해 사이드바에서 룸
+      드롭다운 자체가 노출되지 않도록 한다 (관리자 전용 룸 관리는 ISSUE-29).
+    - DB 조회 실패 시 RL-006 (내부 에러 누설 방지) 에 따라 서버 로그만
+      남기고 빈 리스트를 반환한다.
+    """
+    if not user or user.get("role") == "admin":
+        return []
+    try:
+        return get_room_model().list_by_operator(user["id"])
+    except Exception as e:
+        print(f"[Sidebar] 배정된 룸 조회 실패: {e!r}")
+        return []
+
+
 # === 사이드바 ===
 with st.sidebar:
     st.header("🧑‍💻 유저 정보")
@@ -80,22 +106,61 @@ with st.sidebar:
         st.info("💡 .env 파일에 AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY를 설정하세요")
         st.stop()
 
+    # 룸 선택 (오퍼레이터 전용, ISSUE-27) ----------------------------
+    sidebar_user = get_current_user()
+    assigned_rooms = _load_assigned_rooms_for_user(sidebar_user)
+    selected_room_id = None
+    show_room_section = sidebar_user is not None and sidebar_user.get("role") != "admin"
+
+    if show_room_section:
+        st.markdown("---")
+        st.subheader("🏛️ 배정된 룸")
+        if has_assigned_rooms(assigned_rooms):
+            options = build_room_dropdown_options(assigned_rooms)
+            labels = [opt["label"] for opt in options]
+            ids = [opt["id"] for opt in options]
+            default_id = select_default_room(
+                assigned_rooms, st.session_state.get("selected_room_id")
+            )
+            default_index = ids.index(default_id) if default_id in ids else 0
+            chosen_label = st.selectbox(
+                "룸 선택",
+                options=labels,
+                index=default_index,
+                key="operator_room_selector",
+                help="자막을 송출할 룸을 선택하세요",
+            )
+            selected_room_id = ids[labels.index(chosen_label)]
+            st.session_state["selected_room_id"] = selected_room_id
+        else:
+            st.info("배정된 룸이 없습니다. 관리자에게 문의하세요.")
+
     # 시스템 제어
     st.subheader("🎛️ 시스템 제어")
     col1, col2 = st.columns([1, 1])
 
     current_status = st.session_state.get("action", "idle")
+    # 룸 선택 UI가 노출되는데 룸이 없으면 "시작"을 차단해
+    # 의미 없는 세션 생성을 막는다 (AC2 invariant: 시작 시 room_id 필요).
+    no_room_for_operator = show_room_section and selected_room_id is None
 
     with col1:
-        start_disabled = current_status in [
-            "start",
-            "starting",
-        ]
+        start_disabled = (
+            current_status
+            in [
+                "start",
+                "starting",
+            ]
+            or no_room_for_operator
+        )
         start = st.button(
             "🎯 시작",
             type="primary",
             use_container_width=True,
             disabled=start_disabled,
+            help=(
+                "배정된 룸이 없어 시작할 수 없습니다." if no_room_for_operator else None
+            ),
         )
 
     with col2:
@@ -197,13 +262,13 @@ try:
 
     current_user = get_current_user()
 
-    payload = {
-        "action": st.session_state["action"],
-        "openai_session": st.session_state.get("openai_session"),
-        "service": "openai_realtime",
-        "websocket_port": st.session_state["websocket_port_ref"]["port"],
-        "user_info": current_user,
-    }
+    payload = build_bootstrap_payload(
+        action=st.session_state["action"],
+        openai_session=st.session_state.get("openai_session"),
+        websocket_port=st.session_state["websocket_port_ref"]["port"],
+        user_info=current_user,
+        room_id=st.session_state.get("selected_room_id"),
+    )
 
     html_content = html_template.replace("{{BOOTSTRAP_JSON}}", json.dumps(payload))
     st.components.v1.html(html_content, height=900, scrolling=False)

--- a/database.py
+++ b/database.py
@@ -695,6 +695,23 @@ class Room:
             conn.commit()
             return cursor.rowcount > 0
 
+    def list_by_operator(self, operator_id: int) -> list[dict[str, Any]]:
+        """Return non-closed rooms assigned to the given operator (ISSUE-27).
+
+        - Filters out closed rooms (terminal state, not actionable from the
+          operator UI's start/stop buttons).
+        - Ordered by created_at DESC for deterministic dropdown ordering.
+        - Read-only helper; admin assignment logic lives in ISSUE-29.
+        """
+        with self.db.get_connection() as conn:
+            cursor = conn.execute(
+                "SELECT * FROM rooms WHERE operator_id = ? "
+                "AND status != 'closed' "
+                "ORDER BY created_at DESC",
+                (operator_id,),
+            )
+            return [dict(r) for r in cursor.fetchall()]
+
     # ------------------------------------------------------------------
     # State transitions
     # ------------------------------------------------------------------

--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -67,3 +67,101 @@
 ## Verdict
 
 **APPROVED**. 코드 품질, 보안, 테스트 모두 ship 가능한 수준. Critical/High 결함 없음.
+
+---
+
+# Review Notes — ISSUE-27 (PR #61)
+
+**Reviewer**: Claude Opus 4.7 (automated, team-lead REVIEW phase)
+**Date**: 2026-05-07
+**PR Size**: +534 -11 across 5 files (app.py, database.py, operator_ui.py, tests/test_operator_ui.py, tests/test_rooms_db.py)
+
+## Scope
+
+오퍼레이터 사이드바에 배정된 룸 드롭다운/상태 표시/시작·정지 연결 추가.
+bootstrap JSON에 `room_id` 전달 (실제 룸 격리는 ISSUE-28 영역).
+
+## Code Review
+
+### Strengths (RL compliance)
+
+- **RL-001 (importable modules)** — PASS: 사이드바의 분기·기본값·라벨링이
+  `operator_ui.py` 로 분리되어 있다. 이 모듈은 streamlit/database를 import
+  하지 않아 `tests/test_operator_ui.py` 가 mock 없이 직접 import 한다.
+- **RL-005 (extract-with-tests)** — PASS: 신규 5개 함수 + 1개 DB 메서드에
+  대해 20개 단위 테스트 동반. extraction 후 테스트 부재 패턴 회피.
+- **RL-006 (error leakage)** — PASS: `_load_assigned_rooms_for_user` 의
+  except 블록은 `print(f"[Sidebar] 배정된 룸 조회 실패: {e!r}")` 로 서버
+  로그에만 기록. 클라이언트 메시지 경로 없음. 동시에 fail-closed (빈
+  리스트 → 시작 버튼 비활성) 로 안전하게 동작.
+- **RL-010 (a11y)** — PASS: 새 `st.selectbox("룸 선택", ...)` 는 visible
+  label + `help="자막을 송출할 룸을 선택하세요"` 보유. 시작 버튼이
+  비활성일 때 사유를 `help` 텍스트로 안내 ("배정된 룸이 없어 시작할 수
+  없습니다."). 신규 icon-only 컨트롤 없음.
+- **RL-004 (assertion strength)** — PASS: dropdown 옵션 테스트는
+  `set ==` 정확 비교, payload 테스트는 키별 정확 비교. 약한 assertion
+  (`>= 1` 류) 없음.
+
+### Findings
+
+- **CR-1 (Low)** — `auth.logout_user()` 가 `selected_room_id` 를 명시적으로
+  pop 하지 않는다. 같은 브라우저에서 다른 사용자가 로그인하면 이전
+  사용자의 room id가 session_state에 남아 있다. 그러나
+  `select_default_room`이 새 사용자의 room id 목록에 없으면 첫 룸으로
+  폴백하므로 **정보 누설/오작동 없음**. 방어 in depth 차원에서 ISSUE-29
+  쯤 logout 에 명시적 cleanup 추가를 권장.
+
+- **CR-2 (Nit)** — bootstrap payload에 admin/익명 경로에서도 `room_id` 키가
+  `None` 으로 항상 포함된다. webrtc.html 은 `BOOT.room_id` 의 진위만 보고
+  결정하므로 동작은 동일. 하위 호환성 유지 차원에서 의도된 디자인.
+
+- **CR-3 (Nit)** — `_load_assigned_rooms_for_user(user)` 가 admin 분기와
+  DB 에러 분기 두 가지를 한 함수에 둔다. 가독성은 OK이지만, 향후 admin
+  이 자기 룸을 갖는 시나리오 (ISSUE-29 후속) 가 생기면 조건이 늘어날 수
+  있다. 변경 시 별도 함수로 쪼개도 좋음.
+
+### Edge cases verified
+
+- **Logout → 다른 사용자 로그인**: `select_default_room`의 `last_selected_id
+  in ids` 가드가 정보 누설을 막는다 (CR-1 참조).
+- **DB 조회 실패**: `[]` 반환 → 빈 상태 메시지 + 시작 버튼 비활성 (fail-closed).
+- **Admin 사용자**: `show_room_section=False` → 룸 섹션 미노출, 기존 default
+  룸 동작 유지.
+- **active 상태 중 룸이 closed로 전환**: `list_by_operator` 가 closed 제외 →
+  다음 rerun에서 드롭다운에서 사라짐. 진행 중인 WS 세션은 ISSUE-26 lifecycle
+  로 정리됨.
+
+## Security Findings
+
+없음. 클라이언트→서버 신규 데이터는 `selected_room_id` 문자열 하나뿐이며,
+ISSUE-25 에서 도입된 `_authenticate_client` 의 generic 거부 메시지 경로를
+그대로 통과한다 (RL-002 + RL-006 보장 유지).
+
+## Test Quality Verification
+
+- 신규 테스트 20건 (rooms_db 4 + operator_ui 16). 빈 함수, pass-only,
+  assert 없는 테스트 0건. 단언 갯수: 새 파일 합계 104개 (rooms_db 75 +
+  operator_ui 29 — 기존 테스트 포함 카운트).
+- 테스트 명명이 AC와 매핑됨 (예: `test_list_by_operator_empty_for_unassigned`
+  → AC3, `test_includes_room_id_when_provided` → AC2).
+- 405 passed, lint/format clean (`uv run pytest --no-cov -q`,
+  `ruff check .`, `black --check .` 모두 통과).
+
+## Follow-up suggestions (non-blocking)
+
+1. **CR-1 fix**: `auth.logout_user()` 에 `st.session_state.pop("selected_room_id", None)` 한 줄 추가. 1줄짜리 cleanup이라 별도 issue로 분리하기 애매; ISSUE-29 (admin 룸 관리) 작업 시 같이 정리.
+2. **ISSUE-28 후속**: webrtc.html이 `BOOT.room_id` 를 WS auth 메시지에 포함시키도록 수정. 본 PR은 페이로드까지만 책임진다.
+3. (Optional) operator_ui의 함수에 `pyproject.toml` doctest 활성화 검토. 현재는 일반 unit test 로 충분.
+
+## RL-001 / RL-005 / RL-006 / RL-010 / RL-004 verdict
+
+- **RL-001**: PASS. operator_ui.py 부수효과 없음, 직접 import 가능.
+- **RL-005**: PASS. extraction PR 에 20건의 동반 테스트.
+- **RL-006**: PASS. 신규 client-facing 에러 경로 없음.
+- **RL-010**: PASS. 신규 selectbox label 명시, 비활성 사유 help 텍스트.
+- **RL-004**: PASS. 정확 비교 위주. 약한 assertion 없음.
+
+## Verdict
+
+**APPROVED**. 코드 품질, 보안, 접근성, 테스트 모두 ship 가능. Critical/High
+결함 없음. CR-1은 follow-up으로 충분.

--- a/operator_ui.py
+++ b/operator_ui.py
@@ -1,0 +1,120 @@
+"""
+Operator-UI 사이드바를 위한 순수 함수 모듈 (ISSUE-27).
+
+이 모듈에 있는 모든 함수는 부수효과가 없어야 한다 (RL-001 / RL-005):
+- streamlit, DB, 네트워크 호출 금지
+- 입력 → 출력 매핑만 담당하므로 import-friendly 하다
+
+app.py 사이드바는 이 모듈의 함수를 호출하기만 하고, 자신은 Streamlit
+표시 책임만 진다. 이렇게 분리하지 않으면 test에서 streamlit 부수효과
+때문에 import-time 의존성이 폭발한다 (RL-001).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# 사용자에게 보여줄 룸 상태 라벨. 백엔드 status 코드는 영어이지만
+# 오퍼레이터 UI는 한국어로 표기한다 (issues.md AC4).
+_ROOM_STATUS_LABELS: dict[str, str] = {
+    "waiting": "대기",
+    "active": "활성",
+    "inactive": "비활성",
+    "closed": "종료",
+}
+
+
+def format_room_status_label(status: str) -> str:
+    """Map a backend room status code to its Korean UI label.
+
+    Unknown statuses fall back to the raw string so a future status
+    addition stays visible in the UI instead of silently rendering as
+    empty (which would be a worse UX than a debug-y label).
+    """
+    return _ROOM_STATUS_LABELS.get(status, status)
+
+
+def has_assigned_rooms(rooms: list[dict[str, Any]] | None) -> bool:
+    """True iff the operator has at least one assigned room.
+
+    Accepts ``None`` (e.g., DB lookup error path) and treats it as the
+    empty case so the empty-state message is the safe default branch.
+    """
+    if not rooms:
+        return False
+    return True
+
+
+def build_room_dropdown_options(
+    rooms: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    """Build label/id pairs for a Streamlit ``selectbox``.
+
+    Each option contains:
+      - ``id``: the room's stable id (sent to bootstrap as ``room_id``)
+      - ``label``: human-friendly text including the localized status
+
+    Order is preserved from the input — callers are expected to pass
+    rooms in the order they want shown (typically created_at DESC, the
+    same order :meth:`Room.list_by_operator` returns).
+    """
+    options: list[dict[str, str]] = []
+    for room in rooms:
+        status_label = format_room_status_label(room.get("status", ""))
+        name = room.get("name", room.get("id", ""))
+        options.append(
+            {
+                "id": room["id"],
+                "label": f"{name} ({status_label})",
+            }
+        )
+    return options
+
+
+def select_default_room(
+    rooms: list[dict[str, Any]],
+    last_selected_id: str | None,
+) -> str | None:
+    """Pick the default room id for the dropdown on render.
+
+    Strategy:
+      1. If ``last_selected_id`` is still in ``rooms``, keep it
+         (preserves UX across Streamlit reruns).
+      2. Otherwise return the first room's id.
+      3. Empty list → ``None`` (caller renders empty-state UI).
+    """
+    if not rooms:
+        return None
+    ids = [r["id"] for r in rooms]
+    if last_selected_id and last_selected_id in ids:
+        return last_selected_id
+    return ids[0]
+
+
+def build_bootstrap_payload(
+    *,
+    action: str,
+    openai_session: Any,
+    websocket_port: int | None,
+    user_info: dict[str, Any] | None,
+    room_id: str | None,
+) -> dict[str, Any]:
+    """Build the dict that ``app.py`` injects into ``components/webrtc.html``.
+
+    Centralizing this in a pure function lets us unit-test that:
+      - ISSUE-27 AC2: ``room_id`` is forwarded to the browser bootstrap
+      - all required fields are populated for the existing webrtc.html
+      - the result stays JSON-serializable (webrtc.html receives this
+        via ``json.dumps``)
+
+    Use keyword-only args so callers don't accidentally swap argument
+    order — this protects the security-sensitive ``user_info`` slot.
+    """
+    return {
+        "action": action,
+        "openai_session": openai_session,
+        "service": "openai_realtime",
+        "websocket_port": websocket_port,
+        "user_info": user_info,
+        "room_id": room_id,
+    }

--- a/tests/test_operator_ui.py
+++ b/tests/test_operator_ui.py
@@ -1,0 +1,231 @@
+"""
+operator_ui.py 순수 함수 단위 테스트 (ISSUE-27).
+
+ISSUE-27 사이드바에서 사용하는 룸 선택 로직을 import-friendly 모듈에 분리해
+테스트 가능하게 만든다 (RL-001, RL-005).
+
+검증 대상:
+- format_room_status_label: status 코드 → 사용자에게 보일 한국어 라벨
+- select_default_room: 마지막 선택 룸 우선, 없으면 첫 룸 (active > waiting > inactive)
+- build_bootstrap_payload: app.py가 webrtc.html에 주입하는 dict 생성
+- build_room_dropdown_options: 드롭다운 라벨/내부 id 매핑
+- has_assigned_rooms: 빈 상태 안내 분기
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+# operator_ui.py 자체는 streamlit 의존이 없어야 하지만, 다른 모듈을 통해 임포트 사
+# 슬을 따라가다 streamlit이 끌려 들어올 수 있으므로 안전하게 mock한다.
+if "streamlit" not in sys.modules:
+    sys.modules["streamlit"] = MagicMock()
+if "extra_streamlit_components" not in sys.modules:
+    sys.modules["extra_streamlit_components"] = MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# format_room_status_label
+# ---------------------------------------------------------------------------
+class TestFormatRoomStatusLabel:
+    def test_waiting_label(self):
+        from operator_ui import format_room_status_label
+
+        assert format_room_status_label("waiting") == "대기"
+
+    def test_active_label(self):
+        from operator_ui import format_room_status_label
+
+        assert format_room_status_label("active") == "활성"
+
+    def test_inactive_label(self):
+        from operator_ui import format_room_status_label
+
+        assert format_room_status_label("inactive") == "비활성"
+
+    def test_closed_label(self):
+        from operator_ui import format_room_status_label
+
+        assert format_room_status_label("closed") == "종료"
+
+    def test_unknown_status_falls_back_to_raw(self):
+        """알 수 없는 상태는 원문 그대로 표시 (디버깅 용이성, 빈 라벨 방지)."""
+        from operator_ui import format_room_status_label
+
+        assert format_room_status_label("unknown") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# build_room_dropdown_options
+# ---------------------------------------------------------------------------
+class TestBuildRoomDropdownOptions:
+    def test_empty_list_returns_empty(self):
+        from operator_ui import build_room_dropdown_options
+
+        assert build_room_dropdown_options([]) == []
+
+    def test_single_room_label_includes_status(self):
+        """라벨에 룸 이름과 상태가 모두 표시되어야 AC '상태 표시'를 만족."""
+        from operator_ui import build_room_dropdown_options
+
+        rooms = [{"id": "r-1", "name": "A홀", "status": "active"}]
+        opts = build_room_dropdown_options(rooms)
+        assert len(opts) == 1
+        assert opts[0]["id"] == "r-1"
+        assert "A홀" in opts[0]["label"]
+        assert "활성" in opts[0]["label"]
+
+    def test_multiple_rooms_preserve_order(self):
+        from operator_ui import build_room_dropdown_options
+
+        rooms = [
+            {"id": "r-1", "name": "A홀", "status": "active"},
+            {"id": "r-2", "name": "B홀", "status": "waiting"},
+            {"id": "r-3", "name": "C홀", "status": "inactive"},
+        ]
+        opts = build_room_dropdown_options(rooms)
+        ids = [o["id"] for o in opts]
+        assert ids == ["r-1", "r-2", "r-3"]
+
+    def test_label_contains_status_for_each_known_status(self):
+        from operator_ui import build_room_dropdown_options
+
+        rooms = [
+            {"id": "r-w", "name": "W", "status": "waiting"},
+            {"id": "r-a", "name": "A", "status": "active"},
+            {"id": "r-i", "name": "I", "status": "inactive"},
+        ]
+        labels = [o["label"] for o in build_room_dropdown_options(rooms)]
+        assert any("대기" in label for label in labels)
+        assert any("활성" in label for label in labels)
+        assert any("비활성" in label for label in labels)
+
+
+# ---------------------------------------------------------------------------
+# select_default_room
+# ---------------------------------------------------------------------------
+class TestSelectDefaultRoom:
+    def test_empty_rooms_returns_none(self):
+        from operator_ui import select_default_room
+
+        assert select_default_room([], None) is None
+        assert select_default_room([], "r-1") is None
+
+    def test_last_selected_used_when_still_present(self):
+        """마지막 선택이 여전히 목록에 있으면 그것을 사용한다.
+
+        UX: 새로고침 후에도 같은 룸이 선택된 상태로 유지된다.
+        """
+        from operator_ui import select_default_room
+
+        rooms = [
+            {"id": "r-1", "name": "A", "status": "waiting"},
+            {"id": "r-2", "name": "B", "status": "active"},
+        ]
+        assert select_default_room(rooms, "r-2") == "r-2"
+
+    def test_last_selected_ignored_when_missing(self):
+        """마지막 선택 룸이 더 이상 배정되지 않았으면 첫 번째 룸 폴백."""
+        from operator_ui import select_default_room
+
+        rooms = [
+            {"id": "r-1", "name": "A", "status": "waiting"},
+            {"id": "r-2", "name": "B", "status": "active"},
+        ]
+        assert select_default_room(rooms, "r-99") == "r-1"
+
+    def test_no_last_selected_returns_first(self):
+        from operator_ui import select_default_room
+
+        rooms = [
+            {"id": "r-1", "name": "A", "status": "waiting"},
+            {"id": "r-2", "name": "B", "status": "active"},
+        ]
+        assert select_default_room(rooms, None) == "r-1"
+
+
+# ---------------------------------------------------------------------------
+# has_assigned_rooms
+# ---------------------------------------------------------------------------
+class TestHasAssignedRooms:
+    def test_empty_list_false(self):
+        from operator_ui import has_assigned_rooms
+
+        assert has_assigned_rooms([]) is False
+
+    def test_non_empty_list_true(self):
+        from operator_ui import has_assigned_rooms
+
+        assert has_assigned_rooms([{"id": "r-1"}]) is True
+
+    def test_none_treated_as_empty(self):
+        """DB 에러 등으로 None이 와도 안내 메시지 분기로 수렴."""
+        from operator_ui import has_assigned_rooms
+
+        assert has_assigned_rooms(None) is False
+
+
+# ---------------------------------------------------------------------------
+# build_bootstrap_payload
+# ---------------------------------------------------------------------------
+class TestBuildBootstrapPayload:
+    def test_includes_room_id_when_provided(self):
+        """ISSUE-27 핵심 AC: bootstrap JSON에 room_id가 포함된다."""
+        from operator_ui import build_bootstrap_payload
+
+        payload = build_bootstrap_payload(
+            action="idle",
+            openai_session=None,
+            websocket_port=8765,
+            user_info={"id": 1, "username": "op1"},
+            room_id="r-1",
+        )
+        assert payload["room_id"] == "r-1"
+
+    def test_room_id_omitted_when_none(self):
+        """admin이 평소처럼 default 룸을 쓰는 경로 (room_id 없음). RL-006."""
+        from operator_ui import build_bootstrap_payload
+
+        payload = build_bootstrap_payload(
+            action="idle",
+            openai_session=None,
+            websocket_port=8765,
+            user_info={"id": 1, "username": "admin"},
+            room_id=None,
+        )
+        # webrtc.html은 BOOT.room_id의 진위만 보면 되므로 키가 None으로
+        # 들어가 있는 것은 허용. 다만 명시적인 fallback 동작 보장:
+        assert payload.get("room_id") is None
+
+    def test_contains_required_fields(self):
+        from operator_ui import build_bootstrap_payload
+
+        payload = build_bootstrap_payload(
+            action="start",
+            openai_session={"client_secret": "sk-xxx"},
+            websocket_port=8765,
+            user_info={"id": 1, "username": "op1"},
+            room_id="r-1",
+        )
+        assert payload["action"] == "start"
+        assert payload["openai_session"] == {"client_secret": "sk-xxx"}
+        assert payload["websocket_port"] == 8765
+        assert payload["user_info"]["username"] == "op1"
+        assert payload["service"] == "openai_realtime"
+
+    def test_payload_is_json_serializable(self):
+        """webrtc.html에 json.dumps로 주입되므로 직렬화 가능해야 한다."""
+        import json
+
+        from operator_ui import build_bootstrap_payload
+
+        payload = build_bootstrap_payload(
+            action="idle",
+            openai_session=None,
+            websocket_port=None,
+            user_info={"id": 1, "username": "op1"},
+            room_id="r-1",
+        )
+        # raises TypeError if non-serializable
+        json.dumps(payload)

--- a/tests/test_rooms_db.py
+++ b/tests/test_rooms_db.py
@@ -230,6 +230,96 @@ class TestRoomCrud:
         room = room_model.get_by_id("r-op")
         assert room["operator_id"] == operator_user_id
 
+    # ------------------------------------------------------------------
+    # ISSUE-27: list_by_operator (배정된 룸 조회)
+    # ------------------------------------------------------------------
+    def test_list_by_operator_returns_assigned_rooms(
+        self, room_model, admin_user_id, operator_user_id
+    ):
+        """오퍼레이터에게 배정된 룸만 반환된다 (AC1)."""
+        room_model.create(
+            room_id="r-mine-1",
+            name="MyRoomA",
+            created_by=admin_user_id,
+            operator_id=operator_user_id,
+        )
+        room_model.create(
+            room_id="r-mine-2",
+            name="MyRoomB",
+            created_by=admin_user_id,
+            operator_id=operator_user_id,
+        )
+        # 다른 오퍼레이터에게 배정된 룸 (필터링되어야 함)
+        room_model.create(
+            room_id="r-other",
+            name="OtherRoom",
+            created_by=admin_user_id,
+            operator_id=admin_user_id,
+        )
+        # 배정되지 않은 룸 (필터링되어야 함)
+        room_model.create(
+            room_id="r-unassigned",
+            name="Unassigned",
+            created_by=admin_user_id,
+        )
+
+        rooms = room_model.list_by_operator(operator_user_id)
+        ids = {r["id"] for r in rooms}
+        assert ids == {"r-mine-1", "r-mine-2"}
+
+    def test_list_by_operator_empty_for_unassigned(
+        self, room_model, admin_user_id, operator_user_id
+    ):
+        """배정된 룸이 없는 오퍼레이터는 빈 리스트를 받는다.
+
+        AC3 (배정된 룸이 없습니다 안내 메시지) 분기 진입 조건.
+        """
+        room_model.create(
+            room_id="r-noop",
+            name="No Op",
+            created_by=admin_user_id,
+        )
+        rooms = room_model.list_by_operator(operator_user_id)
+        assert rooms == []
+
+    def test_list_by_operator_excludes_closed_rooms(
+        self, room_model, admin_user_id, operator_user_id
+    ):
+        """종료된 룸은 시작/정지 대상이 아니므로 결과에서 제외한다."""
+        room_model.create(
+            room_id="r-active",
+            name="Active",
+            created_by=admin_user_id,
+            operator_id=operator_user_id,
+        )
+        room_model.create(
+            room_id="r-closed",
+            name="Closed",
+            created_by=admin_user_id,
+            operator_id=operator_user_id,
+        )
+        room_model.transition_status("r-closed", "closed")
+
+        rooms = room_model.list_by_operator(operator_user_id)
+        ids = {r["id"] for r in rooms}
+        assert ids == {"r-active"}
+
+    def test_list_by_operator_includes_status_field(
+        self, room_model, admin_user_id, operator_user_id
+    ):
+        """반환 dict는 UI 라벨링에 필요한 status 필드를 포함한다 (AC4)."""
+        room_model.create(
+            room_id="r-st",
+            name="With Status",
+            created_by=admin_user_id,
+            operator_id=operator_user_id,
+        )
+        rooms = room_model.list_by_operator(operator_user_id)
+        assert len(rooms) == 1
+        assert "status" in rooms[0]
+        assert "name" in rooms[0]
+        assert "id" in rooms[0]
+
 
 # ---------------------------------------------------------------------------
 # State transitions


### PR DESCRIPTION
Closes #45

## Summary
오퍼레이터(role=user)가 자신에게 배정된 룸을 사이드바에서 선택해 자막 파이프라인을 시작/정지할 수 있도록 했다. bootstrap JSON에 `room_id`가 포함되어 webrtc.html에서 룸 격리에 사용 가능 (실제 격리는 ISSUE-28 영역).

## Changes
- `database.py`: `Room.list_by_operator(operator_id)` 추가 (closed 룸 제외, 단순 조회 헬퍼)
- `operator_ui.py` (신규): 사이드바 룸 선택을 위한 부수효과 없는 순수 함수 모음 (RL-001/RL-005)
  - `format_room_status_label`, `build_room_dropdown_options`
  - `select_default_room` — 마지막 선택을 rerun 사이에 보존
  - `has_assigned_rooms`, `build_bootstrap_payload`
- `app.py`: 사이드바 — 오퍼레이터 전용 룸 드롭다운 + 상태 라벨 + 빈 상태 안내. 배정 룸이 없으면 시작 버튼 비활성화. bootstrap payload는 `build_bootstrap_payload`로 통일하고 `room_id` 필드 추가.

## Acceptance Criteria
- [x] 오퍼레이터 로그인 시 배정된 룸 목록이 사이드바에 표시 (admin은 미노출)
- [x] 룸 선택 후 시작 시 bootstrap → WS auth 메시지 경로로 `room_id` 전달
- [x] 배정된 룸이 없으면 "배정된 룸이 없습니다. 관리자에게 문의하세요" 안내
- [x] 드롭다운 라벨에 룸 상태 (대기/활성/비활성) 표시

## Tests
- `tests/test_rooms_db.py` (4 신규): `list_by_operator` — 다른 오퍼레이터/미배정 룸 필터링, 빈 결과, closed 제외, 반환 dict 필드 검증
- `tests/test_operator_ui.py` (16 신규): 상태 라벨, 드롭다운 옵션 생성, 기본 선택 룸, 빈 상태 분기, `room_id` 페이로드 전파 + JSON 직렬화 가능성

## Test Plan
- [x] `uv run pytest --no-cov -q` → 405 passed
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run black --check .` → unchanged

## Notes
- ISSUE-28 (브라우저 컴포넌트 룸 ID 처리)이 후속. 현재 PR은 BOOT.room_id를 webrtc.html에 주입까지만 한다.
- `Room.list_by_operator`는 read-only이며 admin 룸 관리 (ISSUE-29) 영역에 손대지 않았다.