### PR TITLE
[ISSUE-28] feat(ui): 브라우저 컴포넌트에 room_id 전달 및 격리

### DIFF
--- a/app.py
+++ b/app.py
@@ -132,8 +132,18 @@ with st.sidebar:
             )
             selected_room_id = ids[labels.index(chosen_label)]
             st.session_state["selected_room_id"] = selected_room_id
+            # ISSUE-28: 웰컴 화면에 룸 이름을 보여주기 위해 함께 보관.
+            # assigned_rooms 는 이미 메모리에 있으므로 추가 DB 조회 없이 매핑.
+            selected_room = next(
+                (r for r in assigned_rooms if r["id"] == selected_room_id),
+                None,
+            )
+            st.session_state["selected_room_name"] = (
+                selected_room.get("name") if selected_room else None
+            )
         else:
             st.info("배정된 룸이 없습니다. 관리자에게 문의하세요.")
+            st.session_state.pop("selected_room_name", None)
 
     # 시스템 제어
     st.subheader("🎛️ 시스템 제어")
@@ -268,6 +278,8 @@ try:
         websocket_port=st.session_state["websocket_port_ref"]["port"],
         user_info=current_user,
         room_id=st.session_state.get("selected_room_id"),
+        # ISSUE-28 AC3: 웰컴 화면에 룸 이름을 보이기 위한 BOOT 필드.
+        room_name=st.session_state.get("selected_room_name"),
     )
 
     html_content = html_template.replace("{{BOOTSTRAP_JSON}}", json.dumps(payload))

--- a/components/webrtc.html
+++ b/components/webrtc.html
@@ -1011,6 +1011,12 @@ try {
     } else {
       title = `실시간 ${inputName} → ${outputName} 자막`;
     }
+    // ISSUE-28 AC3: 운영자가 룸을 선택했을 때만 룸 이름을 타이틀에 합성한다.
+    // BOOT.room_name 이 비어있는 경로(관리자/단일 룸)에서는 기존 문구를
+    // 그대로 유지해 회귀를 막는다.
+    if (BOOT.room_name) {
+      title = `🎙️ ${BOOT.room_name} — ${title}`;
+    }
 
     // 설명 동적 변경
     let desc;
@@ -1755,15 +1761,21 @@ try {
         if (BOOT.user_info) {
           const inputLang = selInputLang ? selInputLang.value : 'auto';
           const outputLang = selOutputLang ? selOutputLang.value : 'ko';
+          // ISSUE-28: 서버는 auth.room_id 로 룸 격리를 수행한다.
+          // BOOT.room_id 가 비어 있으면 'default' 룸으로 폴백해 ISSUE-27
+          // 이전 동작 (단일 룸) 과의 하위 호환을 유지한다.
+          const authRoomId = BOOT.room_id || 'default';
           openaiWebSocket.send(JSON.stringify({
             type: 'auth',
             user: BOOT.user_info,
+            room_id: authRoomId,
             language_settings: {
               input_lang: inputLang,
               output_lang: outputLang
             }
           }));
           console.log('[Auth] 사용자 정보 전송:', BOOT.user_info.username,
+                       '룸:', authRoomId,
                        '언어:', inputLang, '->', outputLang);
         }
       };

--- a/docs/review_notes.md
+++ b/docs/review_notes.md
@@ -165,3 +165,109 @@ ISSUE-25 에서 도입된 `_authenticate_client` 의 generic 거부 메시지 �
 
 **APPROVED**. 코드 품질, 보안, 접근성, 테스트 모두 ship 가능. Critical/High
 결함 없음. CR-1은 follow-up으로 충분.
+
+---
+
+# Review Notes — ISSUE-28 (PR #62)
+
+**Reviewer**: Claude Opus 4.7 (automated, team-lead REVIEW phase)
+**Date**: 2026-05-07
+**PR Size**: +218 -0 across 6 files (app.py, components/webrtc.html,
+operator_ui.py, tests/test_operator_ui.py, tests/test_webrtc_room_id.py,
+tests/e2e/test_room_id_e2e.py)
+
+## Scope
+
+브라우저 컴포넌트(`webrtc.html`) 가 bootstrap JSON 의 `room_id` 를 읽어
+WebSocket auth 메시지에 포함시키고, 웰컴 화면에 룸 이름을 표시한다.
+ISSUE-27 PR #61 까지로 서버 사이드(룸 격리·라우팅·페이로드 전달)는 끝났고,
+본 PR 은 그 마지막 클라이언트 piece.
+
+## Code Review
+
+### Strengths (RL compliance)
+
+- **RL-008 (capability guards)** — N/A: 새 브라우저 API 도입 없음. 기존
+  WebSocket / DOM API 만 사용. 가드 추가 불필요.
+- **RL-010 (a11y)** — PASS: 웰컴 타이틀은 그대로 `<h1 class="welcome-title">`.
+  `textContent` (innerHTML 아님) 으로 갱신해 스크린리더에 plain text 로
+  전달되며 heading semantic 도 유지. 신규 focusable 컨트롤 없음.
+- **RL-014 (hotfix regression test)** — PASS: 변경된 동작별로 dedicated
+  string-match 테스트 (BOOT.room_id 참조 / auth 블록 내 room_id 키 / 'default'
+  폴백 / BOOT.room_name 참조 / updateWelcomeTranslationRules 내 사용 / user_info
+  · language_settings 회귀 가드) 7건. 각 단언이 실패하면 어느 동작이
+  깨졌는지 즉시 드러남.
+- **RL-004 (assertion strength)** — PASS: 모든 단언이 구체값/구체키 비교.
+  단순 `is not None` 류는 보조 단언으로만 사용 (idx 검색).
+- **RL-005 (extract-with-tests)** — PASS: `build_bootstrap_payload` 의 새
+  키워드 인자 (`room_name`) 에 대해 단위 테스트 2건 즉시 동반.
+
+### Findings
+
+- **CR-1 (Low)** — `BOOT.room_id || 'default'` 폴백 식이 빈 문자열도 'default'
+  로 코어스한다. 이는 의도된 동작 — 서버 `_authenticate_client` 도 빈/누락
+  room_id 를 `DEFAULT_ROOM_ID` 로 매핑하므로 일관됨. **No change.**
+
+- **CR-2 (Info)** — 룸 이름이 매우 길 경우 웰컴 타이틀이 길어질 수 있음.
+  기존 `.welcome-title` CSS 의 overflow 처리로 충분 (max-width + 폰트 크기
+  자동 축소 없음, 줄바꿈 가능). DB 측 룸 이름 길이 제한은 application 레이어
+  에 위임됨. **No change.**
+
+- **CR-3 (Info)** — `app.py` 의 `selected_room_name` 은 has_assigned_rooms
+  분기 안에서만 set 되고, 다른 경로 (admin / 빈 리스트) 에서는 `pop` 으로
+  명시적 cleanup. session 간 stale name 누설 방지 — 잘 처리됨.
+
+### Edge cases verified
+
+- **운영자가 룸을 선택한 뒤 시작 → BOOT.room_id 설정 → auth.room_id 전송**:
+  서버는 ISSUE-25 RoomManager 라우팅으로 해당 룸으로만 자막 broadcast.
+- **admin 또는 룸 미선택 사용자**: `BOOT.room_id` = None →
+  `BOOT.room_id || 'default'` = 'default' → 서버는 DEFAULT_ROOM_ID 로 폴백.
+  ISSUE-27 이전과 동일 동작 (하위 호환).
+- **BOOT.room_name 미존재**: 웰컴 타이틀은 기존 문구 그대로. 회귀 없음.
+- **BOOT.room_name 에 특수문자/HTML**: server 측 `json.dumps` 가 escape 하고,
+  browser 측 `textContent` 가 다시 escape — XSS 표면 변화 없음.
+- **Stop → Start 재시작 (clearViewer 경로)**: line 1549 의
+  `updateWelcomeTranslationRules()` 호출로 room_name 이 다시 적용됨.
+
+## Security Findings
+
+| # | Severity | Finding | Resolution |
+|---|----------|---------|------------|
+| S-1 | None | XSS surface unchanged. `BOOT` is server-side `json.dumps`-encoded; welcome title uses `textContent` (not innerHTML) so room_name is HTML-escaped at render. | None needed. |
+| S-2 | None | Auth payload shape adds only `room_id` (string). Server-side `_authenticate_client` already validates `room_id` (must be pre-registered or fall back to default). No new attack surface. | None needed. |
+| S-3 | None | No long-term credentials, OpenAI tokens, or DB rows are exposed in the new code path. | None needed. |
+
+## Test Quality Verification
+
+- 신규 테스트 9건 (webrtc_room_id 7 + operator_ui 2). 빈 함수/pass-only/
+  assert 없는 테스트 0건. 모든 단언이 구체값 비교.
+- AC 매핑: AC1→test_boot_room_id_is_referenced + test_auth_message_contains_room_id_key,
+  AC2→test_default_fallback_string_present, AC3→test_boot_room_name_is_referenced
+  + test_room_name_used_in_welcome_title.
+- E2E 회귀 가드 (`tests/e2e/test_room_id_e2e.py`) 추가. `e2e` 마크로 기본
+  실행에서 deselect 되어 일반 CI 를 막지 않음.
+- `uv run pytest -q` (worktree venv): 264 passed.
+- `uv run ruff check .`, `uv run ruff format --check`, `uv run black --check`
+  모두 PASS.
+
+## Follow-up suggestions (non-blocking)
+
+1. **ISSUE-29 진행 시**: admin 이 룸 관리 화면에서 작업 중인 룸으로 직접
+   접속 가능해질 경우, BOOT 에 admin override 플래그 도입 검토.
+2. (Optional) `BOOT.room_name` 길이가 일정 이상일 때 ellipsis 처리.
+   현재는 wrap 으로 충분하나 풀스크린 모드에서 시각적 노이즈가 될 수 있음.
+3. (Optional) auth 메시지 형식이 `{type, user, room_id, language_settings}`
+   로 4-필드가 됨. 향후 추가될 필드를 고려해 schema 문서화 권장.
+
+## RL-008 / RL-010 / RL-014 / RL-004 verdict
+
+- **RL-008**: N/A (새 브라우저 API 미사용).
+- **RL-010**: PASS. heading semantic 유지, textContent 사용으로 a11y 안전.
+- **RL-014**: PASS. 변경된 모든 동작에 dedicated regression 테스트.
+- **RL-004**: PASS. 정확값 비교 단언, idx/window 보조 단언만 None-가드.
+
+## Verdict
+
+**APPROVED**. 코드 품질, 보안, 접근성, 테스트 모두 ship 가능. Critical/High
+결함 없음. Confidence: **High**.

--- a/operator_ui.py
+++ b/operator_ui.py
@@ -98,14 +98,21 @@ def build_bootstrap_payload(
     websocket_port: int | None,
     user_info: dict[str, Any] | None,
     room_id: str | None,
+    room_name: str | None = None,
 ) -> dict[str, Any]:
     """Build the dict that ``app.py`` injects into ``components/webrtc.html``.
 
     Centralizing this in a pure function lets us unit-test that:
       - ISSUE-27 AC2: ``room_id`` is forwarded to the browser bootstrap
+      - ISSUE-28 AC3: ``room_name`` is forwarded so the browser welcome
+        screen can render "🎙️ {room_name} — 실시간 자막"
       - all required fields are populated for the existing webrtc.html
       - the result stays JSON-serializable (webrtc.html receives this
         via ``json.dumps``)
+
+    ``room_name`` is keyword-only and optional (defaults to ``None``)
+    so existing call sites and tests that only pass ``room_id`` keep
+    working — this preserves backward compat with ISSUE-27.
 
     Use keyword-only args so callers don't accidentally swap argument
     order — this protects the security-sensitive ``user_info`` slot.
@@ -117,4 +124,5 @@ def build_bootstrap_payload(
         "websocket_port": websocket_port,
         "user_info": user_info,
         "room_id": room_id,
+        "room_name": room_name,
     }

--- a/tests/e2e/test_room_id_e2e.py
+++ b/tests/e2e/test_room_id_e2e.py
@@ -1,0 +1,42 @@
+"""
+ISSUE-28 E2E 테스트.
+
+웰컴 화면이 BOOT.room_name을 사용해 룸 이름을 노출하는지, BOOT 주입이
+정상 작동하는지를 실제 브라우저에서 검증한다.
+
+기존 e2e 패턴 (tests/e2e/test_fullscreen_e2e.py) 의 streamlit_server +
+playwright iframe 흐름을 따른다. 환경에 streamlit + playwright가 설정돼
+있을 때만 자동 실행되며, 그렇지 않은 CI에서는 ``e2e`` 마크가 기본 deselect
+되어 일반 ``pytest -q`` 실행을 막지 않는다.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+
+class TestRoomNameWelcomeDisplay:
+    """웰컴 화면이 BOOT.room_name을 보여주는지 검증 (AC3 e2e)."""
+
+    def test_welcome_title_renders(self, caption_iframe):
+        """웰컴 타이틀 요소가 렌더링되어야 한다 (회귀 가드).
+
+        BOOT.room_name이 없는 경로(테스트 fixture는 admin 로그인이라 룸
+        선택 자체가 없음)에서 기존 타이틀이 깨지지 않는지를 확인한다.
+        """
+        title = caption_iframe.locator(".welcome-title").first
+        title.wait_for(state="visible", timeout=10000)
+        text = title.inner_text()
+        # admin 경로에서는 룸 이름이 비어 있으므로 기본 문구가 그대로 보여야 한다.
+        # 메시지를 짧게 두어 ruff-format/black 의 줄바꿈 충돌을 피한다.
+        assert "자막" in text, "기본 웰컴 타이틀이 회귀해선 안 된다"
+
+
+class TestBootInjection:
+    """BOOT 객체 주입 자체가 끊기지 않는지 회귀 가드."""
+
+    def test_caption_container_present(self, caption_iframe):
+        """captionContainer 가 존재해야 BOOT 스크립트가 정상 진입했음을 의미."""
+        container = caption_iframe.locator("#captionContainer")
+        container.wait_for(state="attached", timeout=10000)
+        assert container.count() == 1

--- a/tests/test_operator_ui.py
+++ b/tests/test_operator_ui.py
@@ -229,3 +229,40 @@ class TestBuildBootstrapPayload:
         )
         # raises TypeError if non-serializable
         json.dumps(payload)
+
+    # ------------------------------------------------------------------
+    # ISSUE-28: room_name forwarded so webrtc.html can show "🎙️ 룸 이름 — ..."
+    # ------------------------------------------------------------------
+    def test_includes_room_name_when_provided(self):
+        """ISSUE-28 AC3: webrtc.html이 룸 이름을 표시할 수 있도록 payload에
+        ``room_name``이 포함된다.
+        """
+        from operator_ui import build_bootstrap_payload
+
+        payload = build_bootstrap_payload(
+            action="start",
+            openai_session=None,
+            websocket_port=8765,
+            user_info={"id": 1, "username": "op1"},
+            room_id="r-1",
+            room_name="A홀 기조연설",
+        )
+        assert payload["room_name"] == "A홀 기조연설"
+
+    def test_room_name_optional_defaults_to_none(self):
+        """admin 또는 room 미선택 경로에서는 room_name이 None이어야 한다.
+
+        webrtc.html은 ``BOOT.room_name``의 진위만 보고 분기하므로 None
+        허용. ISSUE-27 호환성을 위해 키워드 인자는 선택적이어야 한다.
+        """
+        from operator_ui import build_bootstrap_payload
+
+        payload = build_bootstrap_payload(
+            action="idle",
+            openai_session=None,
+            websocket_port=None,
+            user_info=None,
+            room_id=None,
+        )
+        # 기본값이 None이거나 키가 없거나 둘 중 하나만 만족해도 무방하다.
+        assert payload.get("room_name") is None

--- a/tests/test_webrtc_room_id.py
+++ b/tests/test_webrtc_room_id.py
@@ -1,0 +1,107 @@
+"""
+ISSUE-28: 브라우저 컴포넌트(webrtc.html)에 room_id 전달 및 격리 테스트.
+
+검증 목표 (issues.md AC):
+- AC1: WebSocket auth 메시지에 room_id 필드가 포함된다
+- AC2: BOOT.room_id 미존재 시 'default' 룸으로 폴백 (하위 호환)
+- AC3: 웰컴 화면에 현재 룸 이름이 표시된다 (BOOT.room_name이 있을 때)
+
+또한 RL-014 (hotfix regression test) 정신을 따라, 각 변경된 동작별로
+명확한 단일 어서션 테스트를 둔다 — 회귀 시 어느 동작이 깨졌는지 즉시
+드러나도록 한다.
+
+테스트 전략은 기존 프로젝트 패턴 (tests/test_viewport_responsive.py,
+tests/test_fullscreen.py) 의 string-match 방식을 재사용한다.
+"""
+
+from pathlib import Path
+
+WEBRTC_HTML = Path(__file__).parent.parent / "components" / "webrtc.html"
+
+
+def _read_webrtc() -> str:
+    return WEBRTC_HTML.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# AC1: WebSocket auth 메시지에 room_id 필드가 포함된다
+# ---------------------------------------------------------------------------
+class TestAuthMessageIncludesRoomId:
+    def test_boot_room_id_is_referenced(self):
+        """webrtc.html이 BOOT.room_id를 읽어야 한다 (AC1)."""
+        html = _read_webrtc()
+        assert "BOOT.room_id" in html
+
+    def test_auth_message_contains_room_id_key(self):
+        """auth payload에 'room_id' 키가 포함되어야 한다 (AC1).
+
+        단순한 substring으로는 다른 위치의 room_id를 잡을 수 있어 type:'auth'
+        블록 인근(약 600자)을 추출해 검증한다.
+        """
+        html = _read_webrtc()
+        idx = html.find("type: 'auth'")
+        assert idx != -1, "WebSocket auth 메시지를 찾을 수 없다"
+        window = html[idx : idx + 600]
+        assert "room_id" in window
+
+
+# ---------------------------------------------------------------------------
+# AC2: BOOT.room_id 미존재 시 'default' 룸으로 폴백 (하위 호환)
+# ---------------------------------------------------------------------------
+class TestRoomIdDefaultFallback:
+    def test_default_fallback_string_present(self):
+        """폴백 문자열 'default'가 BOOT.room_id 인근에 존재해야 한다 (AC2).
+
+        구현 형태는 ``BOOT.room_id || 'default'`` 또는 동일한 의미의
+        삼항/널 코얼리스가 모두 허용되므로, 인접한 영역에 'default'가
+        등장하는지로 확인한다.
+        """
+        html = _read_webrtc()
+        idx = html.find("BOOT.room_id")
+        assert idx != -1, "BOOT.room_id 참조가 없다"
+        window = html[idx : idx + 80]
+        assert "'default'" in window or '"default"' in window
+
+
+# ---------------------------------------------------------------------------
+# AC3: 웰컴 화면에 현재 룸 이름이 표시된다 (BOOT.room_name이 있을 때)
+# ---------------------------------------------------------------------------
+class TestWelcomeScreenShowsRoomName:
+    def test_boot_room_name_is_referenced(self):
+        """webrtc.html이 BOOT.room_name을 읽어야 한다 (AC3)."""
+        html = _read_webrtc()
+        assert "BOOT.room_name" in html
+
+    def test_room_name_used_in_welcome_title(self):
+        """웰컴 타이틀이 BOOT.room_name을 합성해 보여줘야 한다 (AC3).
+
+        updateWelcomeTranslationRules() 내에서 title을 결정하므로, 해당
+        함수 본문 안에 BOOT.room_name 참조가 있어야 한다.
+        """
+        html = _read_webrtc()
+        marker = "function updateWelcomeTranslationRules"
+        start = html.find(marker)
+        assert start != -1, "updateWelcomeTranslationRules 함수가 없다"
+        body = html[start : start + 2000]
+        assert "BOOT.room_name" in body
+
+
+# ---------------------------------------------------------------------------
+# 회귀 보호 — 기존 동작 유지 (RL-014 정신)
+# ---------------------------------------------------------------------------
+class TestRegressionGuard:
+    def test_user_info_still_in_auth(self):
+        """기존 user_info 전송 동작이 깨지지 않아야 한다."""
+        html = _read_webrtc()
+        idx = html.find("type: 'auth'")
+        assert idx != -1
+        window = html[idx : idx + 600]
+        assert "BOOT.user_info" in window
+
+    def test_language_settings_still_in_auth(self):
+        """기존 language_settings 전송 동작이 깨지지 않아야 한다 (ISSUE-2)."""
+        html = _read_webrtc()
+        idx = html.find("type: 'auth'")
+        assert idx != -1
+        window = html[idx : idx + 600]
+        assert "language_settings" in window


### PR DESCRIPTION
Closes #46

## Summary
- `operator_ui.build_bootstrap_payload`에 `room_name` 키워드 인자 추가 (선택적, 기본 None — ISSUE-27 호환 유지)
- `app.py` 사이드바에서 선택된 룸의 `name`을 `session_state`에 보관하고 bootstrap payload에 전달
- `components/webrtc.html` WebSocket auth 메시지에 `room_id` 필드 포함; `BOOT.room_id` 미존재 시 `'default'`로 폴백 (하위 호환)
- 웰컴 타이틀에 `BOOT.room_name` 합성 (`🎙️ {room_name} — ...`) — room_name이 비어있는 admin/단일 룸 경로는 기존 문구 유지

## Acceptance Criteria
- [x] AC1: WebSocket auth 메시지에 `room_id` 필드가 포함된다
- [x] AC2: `BOOT.room_id`가 없으면 `default` 룸으로 폴백 (하위 호환)
- [x] AC3: 웰컴 화면에 현재 룸 이름이 표시된다 (`BOOT.room_name`이 있을 때)

## Tests
- `tests/test_webrtc_room_id.py` — webrtc.html string-match (BOOT.room_id 참조 / auth 블록 내 room_id 키 / 'default' 폴백 / BOOT.room_name 참조 / updateWelcomeTranslationRules 내 room_name 사용 / user_info·language_settings 회귀 가드) 7케이스
- `tests/test_operator_ui.py` — `build_bootstrap_payload` 에 `room_name` 포함/None 기본값 검증 2케이스 추가
- `tests/e2e/test_room_id_e2e.py` — 웰컴 타이틀 렌더 / captionContainer 부착 회귀 가드 (e2e 마크)
- `uv run pytest -q`: 264 통과 (deselected 9, skipped 1, xfailed 4)

## Related Issues
- ISSUE-25 (#59), ISSUE-27 (#61): 사이드바 룸 선택 + bootstrap payload room_id 포함 — 본 이슈는 그 후속으로 브라우저 측 처리

## Review Lessons
- RL-008 capability guards: 새 브라우저 API 미사용 (BOOT 전달만)
- RL-010 a11y: 웰컴 타이틀의 단순 텍스트 합성으로 기존 헤딩 시멘틱 유지
- RL-014 hotfix regression: 각 변경 동작별 단일 어서션 테스트 + user_info / language_settings 회귀 가드 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)