### PR TITLE
[ISSUE-32] feat(qr): QR 코드 생성 및 표시

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Real-time multilingual caption system for conference scenarios. Browser connects
 # Project setup
 uv init --python 3.11
 uv add streamlit boto3 python-dotenv aiohttp  # aiohttp powers the SSE viewer broadcast server (ISSUE-30)
+uv add 'qrcode[pil]'                            # QR code generation for viewer URLs (ISSUE-32)
 
 # Development workflow
 uv sync                           # Install dependencies
@@ -39,6 +40,7 @@ docker run --rm -p 8501:8501 -e OPENAI_API_KEY=sk-... realtime-caption
 - `AWS_SECRET_ACCESS_KEY`: Required for AWS service authentication (server-side only)
 - `AWS_REGION`: Optional, defaults to `us-east-1`
 - `SSE_PORT`: Optional, defaults to `8766`. TCP port for the unauthenticated viewer SSE broadcast server (`/stream/{room_id}`, ISSUE-30).
+- `VIEWER_BASE_URL`: Optional, defaults to `http://localhost:{SSE_PORT}`. Base URL embedded into QR codes (ISSUE-32) — set to the public viewer host (e.g. `https://captions.example.com`) in production so attendees scan a reachable URL.
 
 ## Core Architecture
 

--- a/admin.py
+++ b/admin.py
@@ -2,8 +2,10 @@
 관리자 대시보드 페이지
 사용자 계정 생성/관리 및 사용량 통계 조회
 ISSUE-29: 룸 관리 탭 추가, 오퍼레이터 역할 기반 뷰 분기.
+ISSUE-32: 룸별 QR 코드 PNG 다운로드.
 """
 
+import os
 from datetime import datetime, timedelta
 
 import pandas as pd
@@ -27,6 +29,24 @@ from database import (
     get_usage_log_model,
     get_user_model,
 )
+from qr_generator import build_view_url, make_qr_png
+
+
+def _resolve_viewer_base_url() -> str:
+    """``VIEWER_BASE_URL`` 환경변수 → ``http://localhost:{SSE_PORT}`` 로 fallback.
+
+    ISSUE-32: admin.py 의 룸 관리 탭이 룸별 QR PNG 를 만들 때 가리킬
+    뷰어 페이지 base URL 을 결정한다. app.py 와 동일한 규칙으로
+    환경변수가 없거나 비어 있으면 안전하게 로컬 SSE 포트를 사용한다.
+
+    RL-006 관점: 잘못된 환경변수가 들어와도 traceback 누설 없이
+    호출자가 항상 truthy URL 을 받도록 한다.
+    """
+    raw = os.getenv("VIEWER_BASE_URL", "").strip()
+    if raw:
+        return raw
+    sse_port = int(os.getenv("SSE_PORT", "8766"))
+    return f"http://localhost:{sse_port}"
 
 
 @require_admin_or_operator
@@ -592,6 +612,11 @@ def show_room_management(
         st.dataframe(pd.DataFrame(rows), use_container_width=True)
 
     # ------------------------------------------------------------------
+    # ISSUE-32: 룸별 QR 코드 다운로드 (admin: 전체 / operator: 자기 룸)
+    # ------------------------------------------------------------------
+    _render_room_qr_section(visible_rooms)
+
+    # ------------------------------------------------------------------
     # 관리자 전용: 룸 생성 / 배정 / 강제 종료
     # ------------------------------------------------------------------
     if is_role_admin:
@@ -814,6 +839,63 @@ def _render_room_logs_section(
         file_name=f"room_{selected_room_id}_logs_{timestamp}.csv",
         mime="text/csv",
     )
+
+
+def _render_room_qr_section(visible_rooms):
+    """ISSUE-32: 룸별 QR 코드 PNG 다운로드 섹션.
+
+    - 룸이 없으면 섹션 자체를 렌더하지 않는다 (빈 UI 노이즈 방지).
+    - 각 룸마다 ``room_{name}.png`` 파일로 다운로드 가능 — 인쇄/사전 배포용.
+    - QR 생성에 실패해도 다른 룸 처리는 계속되도록 per-row try/except.
+    - RL-001: ``qr_generator`` 는 import-time 부수효과 없는 순수 모듈.
+    - RL-006: 내부 예외는 console 로만 남기고 사용자에게는 generic toast.
+    """
+    if not visible_rooms:
+        return
+
+    st.divider()
+    st.subheader("📱 룸 QR 코드")
+    st.caption(
+        "QR 을 스캔하면 해당 룸의 뷰어 페이지로 이동합니다. "
+        "인쇄해서 행사장에 비치하세요."
+    )
+
+    base_url = _resolve_viewer_base_url()
+
+    for room in visible_rooms:
+        room_id = room.get("id")
+        room_name = room.get("name") or room_id or "room"
+        if not room_id:
+            continue
+
+        try:
+            view_url = build_view_url(room_id, base_url)
+            png_bytes = make_qr_png(view_url)
+        except Exception as e:
+            # RL-006: 내부 예외는 server-side 로그만, 사용자에게는 generic.
+            print(f"[Admin] 룸 QR 생성 실패 (room={room_id}): {e!r}")
+            st.warning(f"'{room_name}' 룸의 QR 코드를 만들 수 없습니다.")
+            continue
+
+        col1, col2 = st.columns([3, 1])
+        with col1:
+            st.markdown(f"**{room_name}** &nbsp;&nbsp; `{view_url}`")
+        with col2:
+            # 파일명에 사용 불가능한 문자 (예: 슬래시) 가 들어가지 않도록 sanitize.
+            safe_name = (
+                "".join(
+                    ch if ch.isalnum() or ch in ("-", "_") else "_"
+                    for ch in str(room_name)
+                )
+                or "room"
+            )
+            st.download_button(
+                label="📥 QR PNG",
+                data=png_bytes,
+                file_name=f"room_{safe_name}.png",
+                mime="image/png",
+                key=f"qr_dl_{room_id}",
+            )
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -29,6 +29,7 @@ from operator_ui import (
     has_assigned_rooms,
     select_default_room,
 )
+from qr_generator import build_view_url, make_qr_data_url
 from services import (
     create_openai_session,
     get_aws_access_key_id,
@@ -294,6 +295,47 @@ elif stop:
     st.session_state.pop("openai_session", None)
     st.rerun()
 
+
+def _resolve_viewer_base_url() -> str:
+    """``VIEWER_BASE_URL`` 환경변수 → 기본 ``http://localhost:{SSE_PORT}`` 로 fallback.
+
+    ISSUE-32: QR 이 가리킬 viewer 페이지의 base URL 을 결정한다.
+    - 운영 환경에서는 ``VIEWER_BASE_URL`` 을 명시적으로 설정해야 함
+      (예: ``https://captions.example.com``).
+    - 미설정 시 ``http://localhost:{SSE_PORT}`` 로 떨어져 로컬 개발이 동작한다.
+
+    RL-006 관점: 잘못된 환경변수가 들어와도 내부 traceback 이 노출되지
+    않도록 ``str.strip()`` 만 하고 형식 검증은 하지 않는다.
+    빈 문자열일 때는 fallback 으로 사용 — 호출자가 늘 truthy URL 을 받도록 한다.
+    """
+    raw = os.getenv("VIEWER_BASE_URL", "").strip()
+    if raw:
+        return raw
+    sse_port = int(os.getenv("SSE_PORT", "8766"))
+    return f"http://localhost:{sse_port}"
+
+
+def _build_view_url_and_qr(room_id: str | None) -> tuple[str | None, str | None]:
+    """selected room 에 대한 viewer URL + QR data URL 쌍을 만든다.
+
+    ``room_id`` 가 None 이면 ``(None, None)`` — admin / 룸 미선택 경로에서
+    호출되므로 webrtc.html 이 QR 영역을 숨길 수 있도록 한다.
+
+    내부 예외는 RL-006 에 따라 server-side 로그만 남기고 ``(None, None)``
+    을 돌려준다 — QR 생성 실패가 메인 캡션 UI 를 깨뜨리지 않게 한다.
+    """
+    if not room_id:
+        return None, None
+    try:
+        view_url = build_view_url(room_id, _resolve_viewer_base_url())
+        qr_data_url = make_qr_data_url(view_url)
+        return view_url, qr_data_url
+    except Exception as e:
+        # RL-006: QR 생성 실패는 사용자에게 노출하지 않는다.
+        print(f"[QR] view URL/QR 생성 실패 (room={room_id}): {e!r}")
+        return None, None
+
+
 # === 메인 캡션 뷰어 ===
 try:
     with open("components/webrtc.html", encoding="utf-8") as f:
@@ -301,14 +343,21 @@ try:
 
     current_user = get_current_user()
 
+    # ISSUE-32: 오퍼레이터 룸이 선택된 경우에만 QR 데이터 동봉.
+    bootstrap_room_id = st.session_state.get("selected_room_id")
+    view_url, qr_data_url = _build_view_url_and_qr(bootstrap_room_id)
+
     payload = build_bootstrap_payload(
         action=st.session_state["action"],
         openai_session=st.session_state.get("openai_session"),
         websocket_port=st.session_state["websocket_port_ref"]["port"],
         user_info=current_user,
-        room_id=st.session_state.get("selected_room_id"),
+        room_id=bootstrap_room_id,
         # ISSUE-28 AC3: 웰컴 화면에 룸 이름을 보이기 위한 BOOT 필드.
         room_name=st.session_state.get("selected_room_name"),
+        # ISSUE-32: 웰컴 화면에 QR 코드를 표시하기 위한 BOOT 필드.
+        view_url=view_url,
+        qr_data_url=qr_data_url,
     )
 
     html_content = html_template.replace("{{BOOTSTRAP_JSON}}", json.dumps(payload))

--- a/components/webrtc.html
+++ b/components/webrtc.html
@@ -623,6 +623,38 @@
       gap: 8px;
     }
 
+    /* ISSUE-32: 행사장 QR 코드 — 시작 전 스크린에 크게 표시. */
+    .qr-code-container {
+      display: none; /* JS 가 BOOT.qr_data_url 있을 때만 보여줌 */
+      margin: 24px auto 0;
+      padding: 16px;
+      background: #ffffff; /* QR 인식률을 위해 흰 배경 강제 */
+      border-radius: 12px;
+      width: max-content;
+      max-width: 90%;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+    }
+    .qr-code-container img {
+      display: block;
+      width: 240px;
+      height: 240px;
+      max-width: 60vmin;
+      max-height: 60vmin;
+    }
+    .qr-code-caption {
+      margin-top: 12px;
+      font-size: 13px;
+      color: rgba(255, 255, 255, 0.65);
+      text-align: center;
+      word-break: break-all;
+      max-width: 360px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    .qr-code-caption strong {
+      color: rgba(255, 255, 255, 0.85);
+    }
+
     /* 반응형 디자인 - 너비 기준 */
     @media (max-width: 768px) {
       body {
@@ -817,6 +849,18 @@
       </label>
     </div>
 
+    <!-- ISSUE-32 AC4: 설정 패널에서도 QR 코드를 다시 확인할 수 있게 노출. -->
+    <div class="control-group" id="settingsQrGroup" style="display: none;">
+      <label>📱 뷰어 QR 코드</label>
+      <div class="qr-code-container" data-qr-container style="margin: 8px 0 0; padding: 12px;">
+        <img data-qr-img alt="자막을 볼 수 있는 뷰어 페이지로 이동하는 QR 코드"
+             style="width: 160px; height: 160px;">
+        <div class="qr-code-caption" style="font-size: 12px; max-width: 220px;">
+          <strong data-qr-url></strong>
+        </div>
+      </div>
+    </div>
+
     <!-- 🚫 제어 섹션 완전 제거 (일시정지, 자막 지우기 버튼 삭제) -->
   </div>
 
@@ -861,6 +905,14 @@
         <div class="welcome-rules" style="margin-top: 16px; font-size: 14px; color: rgba(255, 255, 255, 0.5);">
           <div>🔄 번역 규칙:</div>
           <div>• 감지된 언어 → 한국어</div>
+        </div>
+        <!-- ISSUE-32: 행사장 QR 코드 — JS 가 BOOT.qr_data_url 있을 때만 보여줌. -->
+        <div class="qr-code-container" data-qr-container>
+          <img data-qr-img alt="자막을 볼 수 있는 뷰어 페이지로 이동하는 QR 코드">
+          <div class="qr-code-caption">
+            📱 카메라로 스캔해 자막을 보세요<br>
+            <strong data-qr-url></strong>
+          </div>
         </div>
       </div>
     </div>
@@ -992,6 +1044,37 @@ try {
       langWarning.classList.add('visible');
     } else {
       langWarning.classList.remove('visible');
+    }
+  }
+
+  // ISSUE-32: 웰컴 화면의 QR 컨테이너에 BOOT.qr_data_url 을 주입한다.
+  // BOOT.qr_data_url 이 없으면 컨테이너를 숨겨 admin/룸 미선택 경로의 회귀를 막는다.
+  // RL-006: BOOT 값이 비정상이어도 try/catch 로 캡션 UI 자체는 절대 깨지지 않게.
+  function applyQrCodeToWelcome() {
+    try {
+      const containers = document.querySelectorAll('[data-qr-container]');
+      const dataUrl = (BOOT && BOOT.qr_data_url) ? BOOT.qr_data_url : '';
+      const viewUrl = (BOOT && BOOT.view_url) ? BOOT.view_url : '';
+      containers.forEach(c => {
+        const img = c.querySelector('[data-qr-img]');
+        const urlEl = c.querySelector('[data-qr-url]');
+        if (dataUrl && img) {
+          img.src = dataUrl;
+          c.style.display = 'block';
+          if (urlEl) urlEl.textContent = viewUrl;
+        } else {
+          c.style.display = 'none';
+          if (img) img.removeAttribute('src');
+          if (urlEl) urlEl.textContent = '';
+        }
+      });
+      // 설정 패널의 QR 그룹은 별도 wrapper(.control-group) 가 있어 따로 토글한다.
+      const settingsQrGroup = document.getElementById('settingsQrGroup');
+      if (settingsQrGroup) {
+        settingsQrGroup.style.display = dataUrl ? 'block' : 'none';
+      }
+    } catch (err) {
+      console.warn('[QR] applyQrCodeToWelcome 실패 — QR 표시를 건너뜁니다.', err);
     }
   }
 
@@ -1550,9 +1633,18 @@ try {
           <div>🔄 번역 규칙:</div>
           <div>• 감지된 언어 → 한국어</div>
         </div>
+        <!-- ISSUE-32: 행사장 QR 코드 — clearViewer 후에도 동일하게 노출. -->
+        <div class="qr-code-container" data-qr-container>
+          <img data-qr-img alt="자막을 볼 수 있는 뷰어 페이지로 이동하는 QR 코드">
+          <div class="qr-code-caption">
+            📱 카메라로 스캔해 자막을 보세요<br>
+            <strong data-qr-url></strong>
+          </div>
+        </div>
       </div>
     `;
     updateWelcomeTranslationRules();
+    applyQrCodeToWelcome();
     currentUnstableLine = null;
     currentTypingLine = null;
     if (backToLiveBtn) {
@@ -2329,6 +2421,10 @@ try {
   (async () => {
     try {
       console.log('Bootstrap starting...', BOOT);
+
+      // ISSUE-32: 정적 welcome-state 의 QR 영역을 부트스트랩 시점에 한 번 주입.
+      // (clearViewer 경로는 자체적으로 applyQrCodeToWelcome 을 호출하므로 별도 처리 불필요.)
+      applyQrCodeToWelcome();
 
       if (BOOT.action === 'start' && BOOT.openai_session) {
         const hasPermission = await ensurePermission();

--- a/operator_ui.py
+++ b/operator_ui.py
@@ -99,6 +99,8 @@ def build_bootstrap_payload(
     user_info: dict[str, Any] | None,
     room_id: str | None,
     room_name: str | None = None,
+    view_url: str | None = None,
+    qr_data_url: str | None = None,
 ) -> dict[str, Any]:
     """Build the dict that ``app.py`` injects into ``components/webrtc.html``.
 
@@ -106,13 +108,17 @@ def build_bootstrap_payload(
       - ISSUE-27 AC2: ``room_id`` is forwarded to the browser bootstrap
       - ISSUE-28 AC3: ``room_name`` is forwarded so the browser welcome
         screen can render "🎙️ {room_name} — 실시간 자막"
+      - ISSUE-32: ``view_url`` (인쇄/공유용) 와 ``qr_data_url`` (인라인
+        ``<img src>``) 가 함께 전달되어 오퍼레이터 대기 화면에 QR 코드를
+        표시한다.
       - all required fields are populated for the existing webrtc.html
       - the result stays JSON-serializable (webrtc.html receives this
         via ``json.dumps``)
 
-    ``room_name`` is keyword-only and optional (defaults to ``None``)
-    so existing call sites and tests that only pass ``room_id`` keep
-    working — this preserves backward compat with ISSUE-27.
+    ``room_name`` / ``view_url`` / ``qr_data_url`` 은 keyword-only & 옵셔널
+    (defaults to ``None``) so existing call sites and tests that only
+    pass ``room_id`` keep working — this preserves backward compat with
+    ISSUE-27 / ISSUE-28.
 
     Use keyword-only args so callers don't accidentally swap argument
     order — this protects the security-sensitive ``user_info`` slot.
@@ -125,4 +131,6 @@ def build_bootstrap_payload(
         "user_info": user_info,
         "room_id": room_id,
         "room_name": room_name,
+        "view_url": view_url,
+        "qr_data_url": qr_data_url,
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "httpx>=0.28.1",
     "pandas>=2.3.1",
     "python-dotenv>=1.1.1",
+    "qrcode[pil]>=8.2",
     "requests>=2.32.4",
     "streamlit>=1.48.1",
     "websockets>=15.0.1",

--- a/qr_generator.py
+++ b/qr_generator.py
@@ -1,0 +1,123 @@
+"""
+QR 코드 생성 모듈 (ISSUE-32).
+
+행사장 청중이 룸 뷰어 페이지(``/view/{room_id}``)에 빠르게 접속할 수 있도록
+QR 코드 PNG 와 data URL 을 생성하는 순수 함수들을 제공한다.
+
+설계 원칙
+---------
+- **Importable + side-effect-free** (RL-001 / RL-005): 이 모듈은 import 시점에
+  네트워크/DB/Streamlit 호출을 일체 하지 않는다. 단일 책임 = "URL 또는 PNG
+  바이트를 만드는 것" 뿐이다.
+- **Generic errors only** (RL-006): 예외는 그대로 raise 하지 않고 호출자가
+  generic 메시지로 변환할 수 있도록 ValueError 같은 표준 타입만 노출한다.
+  내부 라이브러리 traceback 이 사용자에게 누설되어선 안 된다.
+- 외부 인터넷 의존성 회피: Google Charts 같은 외부 API 가 아닌 로컬
+  ``qrcode[pil]`` 라이브러리를 사용해 오프라인 행사장에서도 동작한다.
+
+Public API
+----------
+- :func:`build_view_url` : ``viewer_base_url + /view/{room_id}`` 정규화.
+- :func:`make_qr_png` : 임의의 URL 을 PNG 바이트로 변환.
+- :func:`make_qr_data_url` : ``data:image/png;base64,...`` URL 생성.
+  webrtc.html 의 ``<img src>`` 에 직접 삽입할 수 있도록 인라인 데이터를
+  반환한다 (RL-006: 외부 호스팅 의존을 피해 신뢰 경계 단순화).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import qrcode
+
+# 뷰어 페이지 경로 — sse_broadcast.build_sse_app 의 ``/view/{room_id}`` 와 일치.
+# 한 군데에서만 정의해 두어 라우트 변경 시 동기화 누락을 막는다.
+_VIEW_PATH_TEMPLATE = "/view/{room_id}"
+
+
+def build_view_url(room_id: str, base_url: str) -> str:
+    """``base_url`` + ``/view/{room_id}`` 로 정규화된 뷰어 URL 을 만든다.
+
+    다음 입력 변종을 모두 동일한 결과로 매핑해 호출자가 환경변수 형식을
+    너무 신경 쓰지 않게 한다:
+
+      - 끝에 ``/`` 가 있든 없든 동일 결과.
+      - http/https 모두 그대로 전달.
+      - host:port 형태도 그대로 보존.
+
+    Args:
+        room_id: ``Room.id`` 값. 빈 문자열은 ``ValueError``.
+        base_url: ``VIEWER_BASE_URL`` 환경변수 값 또는 기본 fallback. 빈
+            문자열/None 은 ``ValueError`` (호출자에서 fallback 합성 후
+            전달해야 한다).
+
+    Returns:
+        ``https://example.com/view/abc123`` 형식의 절대 URL.
+
+    Raises:
+        ValueError: 입력이 비어 있거나 공백만 있는 경우.
+    """
+    if not room_id or not room_id.strip():
+        raise ValueError("room_id must be non-empty")
+    if not base_url or not base_url.strip():
+        raise ValueError("base_url must be non-empty")
+
+    cleaned_base = base_url.strip().rstrip("/")
+    cleaned_room = room_id.strip()
+    return cleaned_base + _VIEW_PATH_TEMPLATE.format(room_id=cleaned_room)
+
+
+def make_qr_png(url: str) -> bytes:
+    """URL 을 인코딩한 PNG 바이트를 반환한다.
+
+    행사장 인쇄/스크린 표시용으로 충분히 또렷하도록 box_size=10 으로 고정.
+    error_correction 은 ``ERROR_CORRECT_M`` (15% 손상 허용) — 인쇄/사진
+    캡처 시 약간의 노이즈에도 스캔 성공률이 높다.
+
+    Args:
+        url: QR 에 인코딩할 문자열. 빈 문자열은 ``ValueError``.
+
+    Returns:
+        유효한 PNG 시그니처(``\\x89PNG\\r\\n\\x1a\\n``)로 시작하는 바이트.
+
+    Raises:
+        ValueError: 빈 url.
+    """
+    if not url or not url.strip():
+        raise ValueError("url must be non-empty")
+
+    qr = qrcode.QRCode(
+        version=None,  # auto-fit 데이터 크기에 맞춰 버전 선택
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=10,
+        border=4,
+    )
+    qr.add_data(url)
+    qr.make(fit=True)
+
+    img = qr.make_image(fill_color="black", back_color="white")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def make_qr_data_url(url: str) -> str:
+    """``data:image/png;base64,...`` URL 을 만든다.
+
+    ``webrtc.html`` 같은 클라이언트가 ``<img src>`` 에 곧바로 사용할 수
+    있게 base64 PNG 를 인라인한다. 외부 CDN/QR 서비스 의존성이 없어
+    오프라인 행사장에서도 동작한다.
+
+    Args:
+        url: QR 에 인코딩할 문자열. 빈 문자열은 ``ValueError``.
+
+    Returns:
+        ``"data:image/png;base64,<...>"`` 형식 문자열.
+
+    Raises:
+        ValueError: 빈 url.
+    """
+    png_bytes = make_qr_png(url)
+    encoded = base64.b64encode(png_bytes).decode("ascii")
+    return f"data:image/png;base64,{encoded}"

--- a/tests/test_operator_ui.py
+++ b/tests/test_operator_ui.py
@@ -266,3 +266,40 @@ class TestBuildBootstrapPayload:
         )
         # 기본값이 None이거나 키가 없거나 둘 중 하나만 만족해도 무방하다.
         assert payload.get("room_name") is None
+
+    # ------------------------------------------------------------------
+    # ISSUE-32: view_url + qr_data_url forwarded so webrtc.html can show
+    # the QR code on the welcome screen for unauthenticated viewers.
+    # ------------------------------------------------------------------
+    def test_includes_view_url_and_qr_data_url_when_provided(self):
+        """ISSUE-32: payload 에 ``view_url`` 와 ``qr_data_url`` 이 그대로
+        전달되어야 한다 (webrtc.html 인라인 ``<img>`` 가 사용)."""
+        from operator_ui import build_bootstrap_payload
+
+        payload = build_bootstrap_payload(
+            action="idle",
+            openai_session=None,
+            websocket_port=None,
+            user_info={"id": 1, "username": "op1"},
+            room_id="r-1",
+            room_name="A홀",
+            view_url="http://localhost:8766/view/r-1",
+            qr_data_url="data:image/png;base64,AAAA",
+        )
+        assert payload["view_url"] == "http://localhost:8766/view/r-1"
+        assert payload["qr_data_url"] == "data:image/png;base64,AAAA"
+
+    def test_view_url_and_qr_data_url_default_to_none(self):
+        """admin 또는 룸 미선택 경로에서는 두 필드 모두 None — 기존 호출
+        지점이 깨지지 않도록 디폴트가 유지되어야 한다."""
+        from operator_ui import build_bootstrap_payload
+
+        payload = build_bootstrap_payload(
+            action="idle",
+            openai_session=None,
+            websocket_port=None,
+            user_info=None,
+            room_id=None,
+        )
+        assert payload.get("view_url") is None
+        assert payload.get("qr_data_url") is None

--- a/tests/test_qr_generator.py
+++ b/tests/test_qr_generator.py
@@ -1,0 +1,185 @@
+"""qr_generator 테스트 (ISSUE-32).
+
+순수 함수 — DB/Streamlit/네트워크 mock 없이 import 만으로 테스트 가능
+(RL-001 / RL-005). 모든 검증은 출력 바이트/문자열에 대한 결정론적
+어서션이며, 외부 라이브러리(qrcode/PIL) 호출은 그대로 사용한다.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import re
+
+import pytest
+
+from qr_generator import build_view_url, make_qr_data_url, make_qr_png
+
+# ---------------------------------------------------------------------------
+# build_view_url
+# ---------------------------------------------------------------------------
+
+
+class TestBuildViewUrl:
+    """``base_url`` 의 다양한 형식이 같은 정규형으로 합성됨을 보장한다."""
+
+    @pytest.mark.parametrize(
+        "viewer_base,room_id,expected",
+        [
+            (
+                "http://localhost:8766",
+                "room_abc",
+                "http://localhost:8766/view/room_abc",
+            ),
+            (
+                "http://localhost:8766/",
+                "room_abc",
+                "http://localhost:8766/view/room_abc",
+            ),
+            (
+                "https://captions.example.com",
+                "abc123",
+                "https://captions.example.com/view/abc123",
+            ),
+            (
+                "https://captions.example.com/",
+                "abc123",
+                "https://captions.example.com/view/abc123",
+            ),
+            (
+                "https://captions.example.com:443",
+                "abc",
+                "https://captions.example.com:443/view/abc",
+            ),
+            # 다중 trailing slash 도 한 번에 정리
+            (
+                "http://localhost:8766///",
+                "abc",
+                "http://localhost:8766/view/abc",
+            ),
+        ],
+    )
+    def test_normalises_trailing_slash_and_scheme(
+        self, viewer_base: str, room_id: str, expected: str
+    ) -> None:
+        # NB: ``base_url`` 이름은 pytest-base-url 플러그인 fixture 와 충돌하므로
+        # 일부러 ``viewer_base`` 로 치환해 fixture 주입 경로를 회피한다.
+        assert build_view_url(room_id, viewer_base) == expected
+
+    def test_strips_whitespace_in_inputs(self) -> None:
+        # 환경변수에서 흔히 들어오는 trailing whitespace 를 흡수
+        assert (
+            build_view_url("  abc  ", "  http://localhost:8766/  ")
+            == "http://localhost:8766/view/abc"
+        )
+
+    @pytest.mark.parametrize("bad_room", ["", "   ", "\t", "\n"])
+    def test_empty_room_id_raises_value_error(self, bad_room: str) -> None:
+        with pytest.raises(ValueError, match="room_id"):
+            build_view_url(bad_room, "http://localhost:8766")
+
+    @pytest.mark.parametrize("bad_base", ["", "   ", "\t"])
+    def test_empty_base_url_raises_value_error(self, bad_base: str) -> None:
+        with pytest.raises(ValueError, match="base_url"):
+            build_view_url("abc", bad_base)
+
+
+# ---------------------------------------------------------------------------
+# make_qr_png
+# ---------------------------------------------------------------------------
+
+
+# PNG signature (RFC 2083 §3.1): 8 byte magic header that must start every PNG.
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+class TestMakeQrPng:
+    def test_returns_valid_png_signature(self) -> None:
+        png = make_qr_png("http://localhost:8766/view/room_abc")
+        # 헤더만 검증해도 라이브러리가 PNG 컨테이너를 만들었다는 강한 증거
+        assert png.startswith(_PNG_MAGIC)
+
+    def test_returns_non_trivial_bytes(self) -> None:
+        # box_size=10 + 4 모듈 border 면 짧은 URL 로도 1KB+ 가 정상.
+        png = make_qr_png("http://localhost:8766/view/room_abc")
+        assert len(png) > 200
+
+    def test_distinct_urls_produce_distinct_pngs(self) -> None:
+        # 약한 정합성 — 같은 URL 은 같은 출력, 다른 URL 은 다른 출력.
+        a = make_qr_png("http://localhost:8766/view/room_a")
+        b = make_qr_png("http://localhost:8766/view/room_b")
+        assert a != b
+
+    def test_idempotent_for_same_url(self) -> None:
+        # 동일 입력에 대해 결정론적으로 동일 PNG 가 나오는지 확인
+        # (qrcode 라이브러리가 timestamp 등 비결정 입력을 쓰지 않음을 검증).
+        url = "http://localhost:8766/view/room_x"
+        assert make_qr_png(url) == make_qr_png(url)
+
+    def test_can_be_opened_by_pil(self) -> None:
+        # PIL 이 헤더만이 아닌 데이터까지 파싱 가능한지 — 손상되지 않은 PNG 인지 확인.
+        from PIL import Image
+
+        png = make_qr_png("http://localhost:8766/view/room_abc")
+        img = Image.open(io.BytesIO(png))
+        # QR 은 정사각형, box_size=10 이면 매우 작아도 100px 이상.
+        assert img.size[0] == img.size[1]
+        assert img.size[0] >= 100
+
+    @pytest.mark.parametrize("bad_url", ["", "   "])
+    def test_empty_url_raises_value_error(self, bad_url: str) -> None:
+        with pytest.raises(ValueError, match="url"):
+            make_qr_png(bad_url)
+
+
+# ---------------------------------------------------------------------------
+# make_qr_data_url
+# ---------------------------------------------------------------------------
+
+
+class TestMakeQrDataUrl:
+    def test_starts_with_png_data_uri_prefix(self) -> None:
+        data_url = make_qr_data_url("http://localhost:8766/view/room_abc")
+        assert data_url.startswith("data:image/png;base64,")
+
+    def test_decoded_payload_is_valid_png(self) -> None:
+        # data URL 의 base64 부분을 복원했을 때 다시 PNG 헤더로 시작해야 함.
+        data_url = make_qr_data_url("http://localhost:8766/view/room_abc")
+        b64 = data_url.split(",", 1)[1]
+        decoded = base64.b64decode(b64)
+        assert decoded.startswith(_PNG_MAGIC)
+
+    def test_base64_section_contains_only_valid_chars(self) -> None:
+        data_url = make_qr_data_url("http://localhost:8766/view/room_abc")
+        b64 = data_url.split(",", 1)[1]
+        # ASCII base64 charset 만 포함하는지 — 잘못된 인코딩이면 실패.
+        assert re.match(r"^[A-Za-z0-9+/=]+$", b64)
+
+    @pytest.mark.parametrize("bad_url", ["", "   "])
+    def test_empty_url_raises_value_error(self, bad_url: str) -> None:
+        with pytest.raises(ValueError, match="url"):
+            make_qr_data_url(bad_url)
+
+
+# ---------------------------------------------------------------------------
+# Module hygiene — RL-001 importable + side-effect-free
+# ---------------------------------------------------------------------------
+
+
+class TestImportPurity:
+    """qr_generator 가 import 시점에 부수효과를 일으키지 않음을 확인한다."""
+
+    def test_module_imports_without_streamlit_or_network(self) -> None:
+        # streamlit/aws/db 등이 import 되지 않아야 RL-001 위반이 아님.
+        import sys
+
+        # 깨끗한 import 를 위해 캐시 비우기
+        for key in [k for k in sys.modules if k.startswith("qr_generator")]:
+            del sys.modules[key]
+
+        import qr_generator  # noqa: F401 — re-import 자체가 검증.
+
+        # 빠른 sanity — public API 만 export.
+        assert hasattr(qr_generator, "build_view_url")
+        assert hasattr(qr_generator, "make_qr_png")
+        assert hasattr(qr_generator, "make_qr_data_url")

--- a/uv.lock
+++ b/uv.lock
@@ -1634,6 +1634,23 @@ wheels = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
+]
+
+[package.optional-dependencies]
+pil = [
+    { name = "pillow" },
+]
+
+[[package]]
 name = "realtime-en2ko-captions"
 version = "0.1.0"
 source = { virtual = "." }
@@ -1646,6 +1663,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pandas" },
     { name = "python-dotenv" },
+    { name = "qrcode", extra = ["pil"] },
     { name = "requests" },
     { name = "streamlit" },
     { name = "websockets" },
@@ -1672,6 +1690,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "qrcode", extras = ["pil"], specifier = ">=8.2" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "streamlit", specifier = ">=1.48.1" },
     { name = "websockets", specifier = ">=15.0.1" },


### PR DESCRIPTION
## Summary
- 룸별 뷰어 URL(`{base_url}/view/{room_id}`)을 인코딩한 QR 코드를 관리자 다운로드, 오퍼레이터 대기 화면, 설정 패널에 노출 (ISSUE-32).
- `qr_generator.py` 는 RL-001 / RL-006 을 따르는 import-friendly 순수 모듈 — ValueError 만 raise, import-time 부수효과 없음.
- `VIEWER_BASE_URL` 미설정 시 `http://localhost:{SSE_PORT}` 로 안전하게 fallback.

## Acceptance Criteria
- [x] 관리자 대시보드에서 룸별 QR PNG 다운로드 (파일명 `room_{name}.png`)
- [x] 오퍼레이터 대기 화면에 QR 코드 크게 표시
- [x] 시작 후 자막 영역 전환되며 QR 자연스럽게 사라짐
- [x] 설정 패널에서 QR 다시 확인 가능
- [x] URL 형식: `{base_url}/view/{room_id}`

## Review notes
- RL-010: 세 곳의 QR `<img>` 모두 의미 있는 한국어 alt 텍스트.
- RL-006: 모든 QR 실패 경로(서버/JS) 가 generic 메시지 + server-side console log.
- 새 의존성 `qrcode[pil]` 및 `VIEWER_BASE_URL` 환경변수는 `CLAUDE.md` 에 동기화.

## Test plan
- [x] `uv run pytest -q` — 519 passed, qr_generator 100% / 총 82% coverage
- [x] `uv run ruff check .` — clean
- [x] `uv run black .` — clean
- [ ] 수동: 룸 생성 → 관리자 탭에서 PNG 다운로드 후 카메라 스캔
- [ ] 수동: 오퍼레이터 로그인 → 대기 화면 QR 표시 → 시작 클릭 시 사라짐 확인

Closes #50