### PR TITLE
fix(sse): detect viewer disconnect within 0.25s (#69)

### DIFF
--- a/sse_broadcast.py
+++ b/sse_broadcast.py
@@ -467,19 +467,59 @@ async def _handle_stream(request: web.Request) -> web.StreamResponse:
         await mgr.unregister_viewer(room_id, requested_lang, queue)
         return resp
 
+    # Watcher task: poll the underlying transport so client TCP close
+    # (FIN/RST) is detected within ~0.5s instead of waiting for the next
+    # heartbeat write to fail. Without this the in-memory viewer count
+    # would lag client disconnects by up to one heartbeat cycle, breaking
+    # ISSUE-33 metrics fidelity (#69).
+    disconnect_event = asyncio.Event()
+
+    async def _watch_disconnect() -> None:
+        while not disconnect_event.is_set():
+            transport = request.transport
+            if transport is None or transport.is_closing():
+                disconnect_event.set()
+                return
+            await asyncio.sleep(0.25)
+
+    watcher = asyncio.create_task(_watch_disconnect())
+
     try:
         while True:
+            get_task = asyncio.create_task(queue.get())
+            disc_task = asyncio.create_task(disconnect_event.wait())
             try:
-                # Periodic timeout doubles as a keep-alive heartbeat —
-                # proxies / browsers that idle-kill connections will see
-                # a ":\n\n" comment line every 15s.
-                payload = await asyncio.wait_for(queue.get(), timeout=15.0)
-            except TimeoutError:
+                # Race the queue read against client disconnect; the 5s
+                # ceiling doubles as a keep-alive heartbeat so idle proxies
+                # don't drop the connection.
+                done, pending = await asyncio.wait(
+                    {get_task, disc_task},
+                    timeout=5.0,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            except asyncio.CancelledError:
+                get_task.cancel()
+                disc_task.cancel()
+                break
+
+            for p in pending:
+                p.cancel()
+
+            if disc_task in done:
+                break
+
+            if not done:
+                # Timed out — emit heartbeat. Failure on write reliably
+                # confirms a dead connection even when transport.is_closing
+                # somehow lags.
                 try:
                     await resp.write(b": ping\n\n")
                 except (ConnectionResetError, asyncio.CancelledError):
                     break
                 continue
+
+            try:
+                payload = get_task.result()
             except asyncio.CancelledError:
                 break
 
@@ -494,6 +534,7 @@ async def _handle_stream(request: web.Request) -> web.StreamResponse:
                 )
                 break
     finally:
+        watcher.cancel()
         await mgr.unregister_viewer(room_id, requested_lang, queue)
 
     return resp


### PR DESCRIPTION
Closes #69

## Bug
\`/stream/{room_id}\` SSE handler waited for the 15s heartbeat timeout to detect closed clients, leaking viewer counts and breaking ISSUE-33 metrics fidelity. Two e2e tests in \`test_viewer_metrics_e2e.py\` were red:
- \`test_single_viewer_count_visible_in_snapshot\` — count never returned to 0 after client.close()
- \`test_concurrent_viewers_reported_per_lang\` — count drifted because of leak from prior test (module-scoped fixture)

## Fix
Race \`queue.get()\` against a disconnect watcher that polls \`request.transport.is_closing()\` every 250ms. Heartbeat ping interval also shortened to 5s.

\`\`\`python
async def _watch_disconnect():
    while not disconnect_event.is_set():
        transport = request.transport
        if transport is None or transport.is_closing():
            disconnect_event.set()
            return
        await asyncio.sleep(0.25)

watcher = asyncio.create_task(_watch_disconnect())
try:
    while True:
        get_task = asyncio.create_task(queue.get())
        disc_task = asyncio.create_task(disconnect_event.wait())
        done, pending = await asyncio.wait(
            {get_task, disc_task}, timeout=5.0, return_when=FIRST_COMPLETED
        )
        ...
finally:
    watcher.cancel()
    await mgr.unregister_viewer(...)
\`\`\`

## Verification

\`\`\`
# Default suite
580 passed, 22 deselected, 30 warnings in 86s — coverage 83.51%

# E2E suite (the failing tests)
22 passed, 580 deselected — all green
\`\`\`

The 3 viewer-metrics e2e tests now pass on first run (previously 2 failing). No regression in any other test.

## Test plan
- [x] Pre-existing 580 unit tests still pass
- [x] All 22 e2e tests pass (incl. the 2 that were red)
- [x] \`uv run ruff check .\` clean
- [x] \`uv run black --check .\` clean
- [ ] CI green (will validate after push)

## Notes
- Per RL-014 (hotfix needs a regression test): the fix is covered by the existing e2e tests which were the failing oracle. They sit under \`pytest.mark.e2e\` (deselected by default), but explicitly target the regression. Consider gating CI on \`-m e2e\` once Playwright/aiohttp infra is reliable in Actions.
- Heartbeat reduced from 15s to 5s — bandwidth impact at expected viewer scale is < 1KB/s/viewer, well below any proxy threshold.
- Watcher task is cancelled in the \`finally\` block so disconnects don't leak background tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)