### PR TITLE
test: lift coverage 84%→92% via 72 ROI tests

### DIFF
--- a/tests/test_auth_streamlit_ui.py
+++ b/tests/test_auth_streamlit_ui.py
@@ -1,0 +1,859 @@
+"""
+auth.py 의 Streamlit-context 분기 + UI 헬퍼 + cookie 안정성 단위 테스트.
+
+대상 분기:
+- check_usage_limit 의 Streamlit-context path (admin/일반/None/raise)
+- display_user_info / display_login_form / display_logout_button
+- get_session_cookie 의 except branch
+- get_cookie_manager 지연 초기화
+
+Pattern: tests/test_auth_module.py 의 mock_streamlit / mock_cookie_manager
+fixture 패턴을 그대로 따른다.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class SessionState(dict):
+    """Streamlit session_state 모방: dict + attribute 접근 모두 지원."""
+
+    def __getattr__(self, key):
+        try:
+            return self[key]
+        except KeyError as exc:
+            raise AttributeError(key) from exc
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+    def __delattr__(self, key):
+        try:
+            del self[key]
+        except KeyError as exc:
+            raise AttributeError(key) from exc
+
+
+@pytest.fixture(autouse=True)
+def mock_streamlit(monkeypatch):
+    """streamlit / extra_streamlit_components 를 stub 으로 교체하고 auth 재로드."""
+    import sys
+
+    mock_st = MagicMock()
+    mock_st.session_state = SessionState()
+    # `with st.sidebar:` 와 `with st.form(...):` 컨텍스트가 무사히 통과하도록
+    # context manager protocol 을 정의해 둔다.
+    mock_st.sidebar.__enter__ = MagicMock(return_value=mock_st.sidebar)
+    mock_st.sidebar.__exit__ = MagicMock(return_value=False)
+    mock_form_ctx = MagicMock()
+    mock_form_ctx.__enter__ = MagicMock(return_value=mock_form_ctx)
+    mock_form_ctx.__exit__ = MagicMock(return_value=False)
+    mock_st.form.return_value = mock_form_ctx
+    mock_esc = MagicMock()
+
+    monkeypatch.setitem(sys.modules, "streamlit", mock_st)
+    monkeypatch.setitem(sys.modules, "extra_streamlit_components", mock_esc)
+    sys.modules.pop("auth", None)
+    yield mock_st
+
+
+@pytest.fixture(autouse=True)
+def set_session_secret(monkeypatch):
+    monkeypatch.setenv("SESSION_SECRET", "test-secret-streamlit-ui")
+
+
+@pytest.fixture
+def mock_cookie_manager():
+    cm = MagicMock()
+    cm.get.return_value = None
+    cm.set = MagicMock()
+    cm.delete = MagicMock()
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# check_usage_limit — Streamlit context path (lines 249-262)
+# ---------------------------------------------------------------------------
+class TestCheckUsageLimitStreamlitPath:
+    """user_info=None 으로 호출했을 때의 Streamlit-context 분기 검증."""
+
+    def test_admin_user_returns_true_regardless_of_remaining(self, mock_streamlit):
+        """role='admin' 이면 remaining 값과 무관하게 True 반환."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": True,
+                "user": {
+                    "id": 1,
+                    "username": "admin",
+                    "role": "admin",
+                    "is_active": True,
+                },
+            }
+        )
+
+        # remaining 이 0 이라도 admin 이므로 True 가 나와야 한다.
+        with patch("auth.get_user_remaining_seconds", return_value=0):
+            from auth import check_usage_limit
+
+            assert check_usage_limit(9999) is True
+
+    def test_regular_user_with_sufficient_remaining_returns_true(self, mock_streamlit):
+        """일반 사용자, remaining >= duration → True."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": True,
+                "user": {
+                    "id": 1,
+                    "username": "alice",
+                    "role": "user",
+                    "is_active": True,
+                },
+            }
+        )
+
+        with patch("auth.get_user_remaining_seconds", return_value=200):
+            from auth import check_usage_limit
+
+            assert check_usage_limit(100) is True
+
+    def test_regular_user_with_insufficient_remaining_returns_false(
+        self, mock_streamlit
+    ):
+        """일반 사용자, remaining < duration → False."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": True,
+                "user": {
+                    "id": 1,
+                    "username": "alice",
+                    "role": "user",
+                    "is_active": True,
+                },
+            }
+        )
+
+        with patch("auth.get_user_remaining_seconds", return_value=50):
+            from auth import check_usage_limit
+
+            assert check_usage_limit(100) is False
+
+    def test_remaining_seconds_none_returns_false(self, mock_streamlit):
+        """get_user_remaining_seconds 가 None → False (조회 실패 fail-closed)."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": True,
+                "user": {
+                    "id": 1,
+                    "username": "alice",
+                    "role": "user",
+                    "is_active": True,
+                },
+            }
+        )
+
+        with patch("auth.get_user_remaining_seconds", return_value=None):
+            from auth import check_usage_limit
+
+            assert check_usage_limit(100) is False
+
+    def test_get_remaining_raises_returns_false(self, mock_streamlit):
+        """get_user_remaining_seconds 가 raise → except 분기에서 False 반환."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": True,
+                "user": {
+                    "id": 1,
+                    "username": "alice",
+                    "role": "user",
+                    "is_active": True,
+                },
+            }
+        )
+
+        with patch(
+            "auth.get_user_remaining_seconds",
+            side_effect=RuntimeError("no streamlit context"),
+        ):
+            from auth import check_usage_limit
+
+            # 절대 예외를 raise 하면 안 된다 — except 가 삼키고 False 반환.
+            assert check_usage_limit(100) is False
+
+    def test_remaining_equals_duration_returns_true(self, mock_streamlit):
+        """remaining == duration → True (>= 비교 경계값)."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": True,
+                "user": {
+                    "id": 1,
+                    "username": "alice",
+                    "role": "user",
+                    "is_active": True,
+                },
+            }
+        )
+
+        with patch("auth.get_user_remaining_seconds", return_value=100):
+            from auth import check_usage_limit
+
+            assert check_usage_limit(100) is True
+
+
+# ---------------------------------------------------------------------------
+# display_user_info (lines 332-372)
+# ---------------------------------------------------------------------------
+class TestDisplayUserInfo:
+    """display_user_info 의 분기별 사이드바 렌더링 검증."""
+
+    def test_no_authenticated_user_returns_early_no_writes(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """get_current_user() 가 None → early return, sidebar.write 미호출."""
+        mock_streamlit.session_state = SessionState(
+            {"authenticated": False, "user": None}
+        )
+
+        with patch("auth.get_cookie_manager", return_value=mock_cookie_manager):
+            from auth import display_user_info
+
+            display_user_info()
+
+        # 어떤 sidebar 위젯도 호출되지 않아야 한다.
+        mock_streamlit.sidebar.write.assert_not_called()
+        mock_streamlit.button.assert_not_called()
+
+    def test_user_with_full_name_writes_username_and_affiliation(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """full_name 이 있으면 username + 소속 (총 2회) write 호출."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": True,
+                "user": {
+                    "id": 1,
+                    "username": "alice",
+                    "full_name": "Alice Co.",
+                    "role": "user",
+                    "is_active": True,
+                },
+            }
+        )
+        # 로그아웃 버튼은 클릭되지 않은 상태 (False).
+        mock_streamlit.button.return_value = False
+
+        with patch("auth.get_cookie_manager", return_value=mock_cookie_manager):
+            from auth import display_user_info
+
+            display_user_info()
+
+        # username + 소속 = 정확히 2회 호출.
+        assert mock_streamlit.write.call_count == 2
+        first_arg = mock_streamlit.write.call_args_list[0].args[0]
+        second_arg = mock_streamlit.write.call_args_list[1].args[0]
+        assert "alice" in first_arg
+        assert "아이디" in first_arg
+        assert "Alice Co." in second_arg
+        assert "소속" in second_arg
+
+    def test_user_without_full_name_writes_only_username(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """full_name 이 falsy 이면 username 만 (1회) write 호출."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": True,
+                "user": {
+                    "id": 2,
+                    "username": "bob",
+                    "full_name": None,
+                    "role": "user",
+                    "is_active": True,
+                },
+            }
+        )
+        mock_streamlit.button.return_value = False
+
+        with patch("auth.get_cookie_manager", return_value=mock_cookie_manager):
+            from auth import display_user_info
+
+            display_user_info()
+
+        # 정확히 1회 — 소속 라인은 렌더링되지 않아야 한다.
+        assert mock_streamlit.write.call_count == 1
+        only_arg = mock_streamlit.write.call_args_list[0].args[0]
+        assert "bob" in only_arg
+        assert "소속" not in only_arg
+
+    def test_logout_button_clicked_calls_logout_and_rerun(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """로그아웃 버튼이 클릭되면 logout_user() 호출 + st.rerun() 호출."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": True,
+                "user": {
+                    "id": 1,
+                    "username": "alice",
+                    "full_name": None,
+                    "role": "user",
+                    "is_active": True,
+                },
+            }
+        )
+        # 버튼 클릭됨.
+        mock_streamlit.button.return_value = True
+
+        with patch("auth.get_cookie_manager", return_value=mock_cookie_manager):
+            from auth import display_user_info
+
+            display_user_info()
+
+        # 로그아웃이 실행되어 세션이 초기화돼야 한다.
+        assert mock_streamlit.session_state["authenticated"] is False
+        assert mock_streamlit.session_state["user"] is None
+        # 쿠키 삭제 + rerun 호출이 있어야 한다.
+        mock_cookie_manager.delete.assert_called_once_with("user_session")
+        mock_streamlit.rerun.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# display_login_form (lines 378-445)
+# ---------------------------------------------------------------------------
+class TestDisplayLoginForm:
+    """display_login_form 의 분기 검증 — 인증된 상태 / 폼 렌더링 / 제출 처리."""
+
+    def test_already_authenticated_returns_true_early(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """이미 인증된 상태 → True 반환, 폼 렌더링/제출 처리 없음."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": True,
+                "user": {"id": 1, "username": "alice", "is_active": True},
+            }
+        )
+
+        with patch("auth.get_cookie_manager", return_value=mock_cookie_manager):
+            from auth import display_login_form
+
+            result = display_login_form()
+
+        assert result is True
+        # 폼이 그려지면 안 된다.
+        mock_streamlit.form.assert_not_called()
+        mock_streamlit.title.assert_not_called()
+
+    def test_unauthenticated_renders_login_form(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """미인증 + login_submitted=False → 로그인 폼 (title + form) 렌더링."""
+        mock_streamlit.session_state = SessionState(
+            {"authenticated": False, "user": None}
+        )
+        # 폼 안의 widget 들의 반환값. 사용자가 아무 것도 입력하지 않은 상태.
+        mock_streamlit.text_input.return_value = ""
+        mock_streamlit.form_submit_button.return_value = False  # 제출 안 됨
+
+        with patch("auth.get_cookie_manager", return_value=mock_cookie_manager):
+            from auth import display_login_form
+
+            result = display_login_form()
+
+        assert result is False
+        mock_streamlit.title.assert_called_once()
+        mock_streamlit.form.assert_called_once_with("login_form")
+        # 사용자명 + 비밀번호 input → 정확히 2회 호출.
+        assert mock_streamlit.text_input.call_count == 2
+        mock_streamlit.form_submit_button.assert_called_once()
+
+    def test_form_submit_with_empty_credentials_shows_error(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """폼 제출됐지만 username/password 가 비어 있으면 st.error 호출."""
+        mock_streamlit.session_state = SessionState(
+            {"authenticated": False, "user": None}
+        )
+        # 사용자가 아무것도 입력하지 않은 채 제출.
+        mock_streamlit.text_input.return_value = ""
+        mock_streamlit.form_submit_button.return_value = True
+
+        with patch("auth.get_cookie_manager", return_value=mock_cookie_manager):
+            from auth import display_login_form
+
+            result = display_login_form()
+
+        assert result is False
+        mock_streamlit.error.assert_called_once()
+        msg = mock_streamlit.error.call_args.args[0]
+        # 메시지에 사용자명/비밀번호 안내가 포함돼야 한다.
+        assert "사용자명" in msg or "비밀번호" in msg
+        # login_submitted 는 set 되면 안 된다 — 빈 입력은 그냥 에러.
+        assert mock_streamlit.session_state.get("login_submitted") is not True
+
+    def test_form_submit_with_credentials_sets_login_submitted_state(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """username/password 모두 채워져 제출 → temp_* 와 login_submitted=True 설정."""
+        mock_streamlit.session_state = SessionState(
+            {"authenticated": False, "user": None}
+        )
+        # text_input 호출 순서: 사용자명 → 비밀번호.
+        mock_streamlit.text_input.side_effect = ["alice", "alicepass"]
+        mock_streamlit.form_submit_button.return_value = True
+
+        with patch("auth.get_cookie_manager", return_value=mock_cookie_manager):
+            from auth import display_login_form
+
+            result = display_login_form()
+
+        assert result is False
+        assert mock_streamlit.session_state["temp_username"] == "alice"
+        assert mock_streamlit.session_state["temp_password"] == "alicepass"
+        assert mock_streamlit.session_state["login_submitted"] is True
+        mock_streamlit.rerun.assert_called_once()
+        # 정상 제출이면 error 는 없어야 한다.
+        mock_streamlit.error.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# get_session_cookie / get_cookie_manager (lines 73-75, 98-100)
+# ---------------------------------------------------------------------------
+class TestGetSessionCookieErrorPath:
+    """get_session_cookie 의 except 분기 — CookieManager 가 raise 해도 None 반환."""
+
+    def test_cookie_manager_get_raises_returns_none(self, mock_streamlit, capsys):
+        """CookieManager.get(...) 이 raise → 함수는 None 반환 + 서버 로그."""
+        cm = MagicMock()
+        cm.get.side_effect = RuntimeError("boom — no streamlit context")
+
+        with patch("auth.get_cookie_manager", return_value=cm):
+            from auth import get_session_cookie
+
+            # 절대 raise 해서는 안 됨. except 가 삼키고 None.
+            result = get_session_cookie()
+
+        assert result is None
+        # RL-006 흐름과 동일하게 서버에 로깅돼야 한다 (디테일 흘리지 않음).
+        captured = capsys.readouterr()
+        assert "[Auth]" in captured.out
+        assert "쿠키 읽기 실패" in captured.out
+
+    def test_cookie_manager_returns_none_returns_none(self, mock_streamlit):
+        """CookieManager.get(...) 이 None 을 반환 → 함수도 None 반환 (정상)."""
+        cm = MagicMock()
+        cm.get.return_value = None
+
+        with patch("auth.get_cookie_manager", return_value=cm):
+            from auth import get_session_cookie
+
+            assert get_session_cookie() is None
+
+    def test_cookie_manager_returns_empty_string_returns_none(self, mock_streamlit):
+        """빈 문자열 → falsy 분기 → None 반환."""
+        cm = MagicMock()
+        cm.get.return_value = ""
+
+        with patch("auth.get_cookie_manager", return_value=cm):
+            from auth import get_session_cookie
+
+            assert get_session_cookie() is None
+
+
+class TestGetCookieManagerLazyInit:
+    """get_cookie_manager 의 지연 초기화 분기."""
+
+    def test_lazy_init_creates_manager_on_first_call(self, mock_streamlit, monkeypatch):
+        """첫 호출에서만 CookieManager 가 인스턴스화되고, 이후 호출은 동일 객체 반환."""
+        import sys
+
+        instances = []
+
+        class _FakeCookieManager:
+            def __init__(self, key):
+                instances.append(self)
+                self.key = key
+
+        # extra_streamlit_components 의 CookieManager 만 교체.
+        fake_module = MagicMock()
+        fake_module.CookieManager = _FakeCookieManager
+        monkeypatch.setitem(sys.modules, "extra_streamlit_components", fake_module)
+        sys.modules.pop("auth", None)
+
+        # auth 모듈의 _cookie_manager 모듈 글로벌이 None 으로 초기화됐는지 확인.
+        import auth as auth_module
+        from auth import get_cookie_manager
+
+        auth_module._cookie_manager = None
+
+        first = get_cookie_manager()
+        second = get_cookie_manager()
+
+        assert first is second
+        # 정확히 한 번만 instantiate 돼야 한다 (race-free 멱등).
+        assert len(instances) == 1
+        assert instances[0].key == "auth_cookie_manager"
+
+
+# ---------------------------------------------------------------------------
+# _verify_cookie split error path (lines 62-63) — TypeError 가 raise 되는 입력
+# ---------------------------------------------------------------------------
+class TestVerifyCookieDefensiveErrorHandling:
+    """_verify_cookie 의 except (ValueError, TypeError) 분기 — 비-문자열 입력."""
+
+    def test_verify_cookie_with_non_string_returns_none(self, mock_streamlit):
+        """문자열이 아닌 입력 (예: None, list) → None 반환, raise 안 함."""
+        from auth import _verify_cookie
+
+        # rsplit 자체가 None 에는 호출 불가하지만, 실제로는 split 단계에서
+        # ValueError 또는 TypeError 가 날 수 있는 다양한 입력에 대한 방어막.
+        # 빈 문자열 → rsplit(":", 1) → [""] 길이 1 → return None.
+        assert _verify_cookie("") is None
+        # 콜론 1개만 있는 경우 → split(":", 2) 가 길이 2 가 되어 ValueError.
+        assert _verify_cookie("a:b") is None
+        # 잘못된 형식 (HMAC 미스매치).
+        assert _verify_cookie("wrong:format:no:hmac") is None
+
+
+# ---------------------------------------------------------------------------
+# display_login_form — login_submitted=True 처리 경로 (lines 384-425)
+# ---------------------------------------------------------------------------
+class TestDisplayLoginFormSubmittedFlow:
+    """폼 제출 후 다음 rerun 에서 로그인 처리되는 분기 검증."""
+
+    def test_login_submitted_with_valid_credentials_logs_in_and_reruns(
+        self, mock_streamlit, mock_cookie_manager, monkeypatch
+    ):
+        """login_submitted=True + temp_username/password 가 valid → login_user 성공.
+
+        - markdown / info 가 호출되어 로딩 화면이 표시되고
+        - login_user() 가 True 반환 시 temp_* / login_submitted 가 정리되고
+        - st.rerun 이 호출돼야 한다.
+        """
+        # time.sleep 을 모킹해 테스트 시간 단축.
+        import auth as _auth_preview  # noqa: F401  -- ensure we import a fresh copy
+
+        # 사전: session_state 에 login_submitted + temp_* 세팅.
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": False,
+                "user": None,
+                "login_submitted": True,
+                "temp_username": "alice",
+                "temp_password": "alicepass",
+            }
+        )
+
+        # login_user 가 True 를 반환하도록 모킹 (DB 의존 제거).
+        from auth import display_login_form
+
+        # auth 모듈의 time.sleep 을 즉시 반환하는 stub 으로 교체.
+        monkeypatch.setattr("auth.time.sleep", lambda _: None)
+
+        with (
+            patch("auth.get_cookie_manager", return_value=mock_cookie_manager),
+            patch("auth.login_user", return_value=True) as mock_login,
+        ):
+            result = display_login_form()
+
+        assert result is False  # 함수는 항상 False 반환 (rerun 후 재진입에서 True)
+        mock_login.assert_called_once_with("alice", "alicepass")
+        # 로딩 UI 가 그려져야 한다.
+        mock_streamlit.markdown.assert_called_once()
+        mock_streamlit.info.assert_called_once()
+        # 임시 데이터 / 플래그 정리.
+        assert "temp_username" not in mock_streamlit.session_state
+        assert "temp_password" not in mock_streamlit.session_state
+        assert "login_submitted" not in mock_streamlit.session_state
+        mock_streamlit.rerun.assert_called_once()
+
+    def test_login_submitted_with_invalid_credentials_shows_error(
+        self, mock_streamlit, mock_cookie_manager, monkeypatch
+    ):
+        """login_user() 가 False 반환 → st.error + login_submitted=False + rerun."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": False,
+                "user": None,
+                "login_submitted": True,
+                "temp_username": "alice",
+                "temp_password": "WRONG",
+            }
+        )
+        monkeypatch.setattr("auth.time.sleep", lambda _: None)
+
+        with (
+            patch("auth.get_cookie_manager", return_value=mock_cookie_manager),
+            patch("auth.login_user", return_value=False) as mock_login,
+        ):
+            from auth import display_login_form
+
+            result = display_login_form()
+
+        assert result is False
+        mock_login.assert_called_once_with("alice", "WRONG")
+        # 실패 메시지가 st.error 로 표시돼야 한다.
+        mock_streamlit.error.assert_called_once()
+        msg = mock_streamlit.error.call_args.args[0]
+        assert "잘못되었습니다" in msg or "비밀번호" in msg
+        # login_submitted 가 False 로 reset, temp_* 는 정리.
+        assert mock_streamlit.session_state["login_submitted"] is False
+        assert "temp_username" not in mock_streamlit.session_state
+        assert "temp_password" not in mock_streamlit.session_state
+        mock_streamlit.rerun.assert_called_once()
+
+    def test_login_submitted_without_temp_credentials_returns_false_no_login(
+        self, mock_streamlit, mock_cookie_manager, monkeypatch
+    ):
+        """login_submitted=True 이지만 temp_* 가 비어 있으면 login_user 호출 안 함."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": False,
+                "user": None,
+                "login_submitted": True,
+                # temp_username / temp_password 미설정.
+            }
+        )
+        monkeypatch.setattr("auth.time.sleep", lambda _: None)
+
+        with (
+            patch("auth.get_cookie_manager", return_value=mock_cookie_manager),
+            patch("auth.login_user") as mock_login,
+        ):
+            from auth import display_login_form
+
+            result = display_login_form()
+
+        assert result is False
+        mock_login.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# update_user_session (lines 450-461)
+# ---------------------------------------------------------------------------
+class TestUpdateUserSession:
+    """update_user_session 분기 검증 — 인증 상태 / user_id 일치 여부 / DB 결과."""
+
+    def test_unauthenticated_returns_early_no_db_call(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """미인증이면 함수가 early return — DB 조회 없음."""
+        mock_streamlit.session_state = SessionState(
+            {"authenticated": False, "user": None}
+        )
+
+        mock_user_model = MagicMock()
+        with (
+            patch("auth.get_cookie_manager", return_value=mock_cookie_manager),
+            patch("auth.get_user_model", return_value=mock_user_model),
+        ):
+            from auth import update_user_session
+
+            update_user_session(1)
+
+        # DB 가 호출되지 않아야 한다.
+        mock_user_model.get_user_by_id.assert_not_called()
+        # session.user 가 변경되지 않아야 한다.
+        assert mock_streamlit.session_state.get("user") is None
+
+    def test_user_id_mismatch_returns_early_no_overwrite(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """현재 session.user 의 id 와 인자 user_id 가 다르면 early return."""
+        original_user = {"id": 1, "username": "alice", "is_active": True}
+        mock_streamlit.session_state = SessionState(
+            {"authenticated": True, "user": original_user}
+        )
+
+        mock_user_model = MagicMock()
+        with (
+            patch("auth.get_cookie_manager", return_value=mock_cookie_manager),
+            patch("auth.get_user_model", return_value=mock_user_model),
+        ):
+            from auth import update_user_session
+
+            update_user_session(2)  # 의도적으로 다른 user_id
+
+        # 다른 사용자 id 면 DB 도 만지면 안 되고, session.user 도 그대로.
+        mock_user_model.get_user_by_id.assert_not_called()
+        assert mock_streamlit.session_state["user"] is original_user
+
+    def test_user_id_match_overwrites_session_user_with_fresh_db_row(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """user_id 가 일치하고 DB 에 row 가 있으면 session.user 를 갱신한다."""
+        original_user = {
+            "id": 1,
+            "username": "alice",
+            "is_active": True,
+            "total_usage_seconds": 0,
+        }
+        fresh_user = {
+            "id": 1,
+            "username": "alice",
+            "is_active": True,
+            "total_usage_seconds": 1234,
+        }
+        mock_streamlit.session_state = SessionState(
+            {"authenticated": True, "user": original_user}
+        )
+
+        mock_user_model = MagicMock()
+        mock_user_model.get_user_by_id.return_value = fresh_user
+        with (
+            patch("auth.get_cookie_manager", return_value=mock_cookie_manager),
+            patch("auth.get_user_model", return_value=mock_user_model),
+        ):
+            from auth import update_user_session
+
+            update_user_session(1)
+
+        mock_user_model.get_user_by_id.assert_called_once_with(1)
+        # session.user 가 갱신돼야 한다.
+        assert mock_streamlit.session_state["user"] == fresh_user
+        assert mock_streamlit.session_state["user"]["total_usage_seconds"] == 1234
+
+    def test_user_id_match_db_returns_none_keeps_old_user(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """DB 가 None 을 반환하면 session.user 를 덮어쓰지 않는다 (방어)."""
+        original_user = {"id": 1, "username": "alice", "is_active": True}
+        mock_streamlit.session_state = SessionState(
+            {"authenticated": True, "user": original_user}
+        )
+
+        mock_user_model = MagicMock()
+        mock_user_model.get_user_by_id.return_value = None
+        with (
+            patch("auth.get_cookie_manager", return_value=mock_cookie_manager),
+            patch("auth.get_user_model", return_value=mock_user_model),
+        ):
+            from auth import update_user_session
+
+            update_user_session(1)
+
+        # DB 가 None 이면 session.user 는 그대로 유지돼야 한다.
+        assert mock_streamlit.session_state["user"] is original_user
+
+
+# ---------------------------------------------------------------------------
+# get_user_remaining_seconds (lines 227-232)
+# ---------------------------------------------------------------------------
+class TestGetUserRemainingSeconds:
+    """get_user_remaining_seconds — 인증 상태별 분기."""
+
+    def test_returns_none_when_no_user(self, mock_streamlit, mock_cookie_manager):
+        """미인증 / user 없음 → None 반환, DB 미호출."""
+        mock_streamlit.session_state = SessionState(
+            {"authenticated": False, "user": None}
+        )
+
+        mock_user_model = MagicMock()
+        with (
+            patch("auth.get_cookie_manager", return_value=mock_cookie_manager),
+            patch("auth.get_user_model", return_value=mock_user_model),
+        ):
+            from auth import get_user_remaining_seconds
+
+            result = get_user_remaining_seconds()
+
+        assert result is None
+        mock_user_model.get_remaining_seconds.assert_not_called()
+
+    def test_returns_db_value_when_user_present(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """인증된 사용자 → DB 의 get_remaining_seconds 반환값 그대로 패스스루."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": True,
+                "user": {"id": 7, "username": "alice", "is_active": True},
+            }
+        )
+
+        mock_user_model = MagicMock()
+        mock_user_model.get_remaining_seconds.return_value = 333
+        with (
+            patch("auth.get_cookie_manager", return_value=mock_cookie_manager),
+            patch("auth.get_user_model", return_value=mock_user_model),
+        ):
+            from auth import get_user_remaining_seconds
+
+            result = get_user_remaining_seconds()
+
+        assert result == 333
+        mock_user_model.get_remaining_seconds.assert_called_once_with(7)
+
+
+# ---------------------------------------------------------------------------
+# init_session_state (lines 111, 113, 115, 122-123)
+# ---------------------------------------------------------------------------
+class TestInitSessionState:
+    """init_session_state — session_state 키 초기화 + 쿠키 복원 시도."""
+
+    def test_init_sets_default_keys_when_empty(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """비어 있는 session_state → 기본 키 (authenticated/user/...) 세팅."""
+        mock_streamlit.session_state = SessionState()
+
+        with (
+            patch("auth.get_cookie_manager", return_value=mock_cookie_manager),
+            patch("auth.restore_session_from_cookie", return_value=False),
+        ):
+            from auth import init_session_state
+
+            init_session_state()
+
+        assert mock_streamlit.session_state["authenticated"] is False
+        assert mock_streamlit.session_state["user"] is None
+        # restore 를 시도했으므로 attempted=True 로 세팅돼야 한다.
+        assert mock_streamlit.session_state["cookie_restore_attempted"] is True
+
+    def test_init_attempts_cookie_restore_only_once(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """attempted=True 이면 restore_session_from_cookie 가 호출되지 않는다."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": False,
+                "user": None,
+                "cookie_restore_attempted": True,
+            }
+        )
+
+        restore_mock = MagicMock(return_value=False)
+        with (
+            patch("auth.get_cookie_manager", return_value=mock_cookie_manager),
+            patch("auth.restore_session_from_cookie", restore_mock),
+        ):
+            from auth import init_session_state
+
+            init_session_state()
+
+        restore_mock.assert_not_called()
+
+    def test_init_skips_restore_when_already_authenticated(
+        self, mock_streamlit, mock_cookie_manager
+    ):
+        """이미 authenticated=True 면 restore 시도하지 않는다."""
+        mock_streamlit.session_state = SessionState(
+            {
+                "authenticated": True,
+                "user": {"id": 1, "username": "alice", "is_active": True},
+                "cookie_restore_attempted": False,
+            }
+        )
+
+        restore_mock = MagicMock(return_value=False)
+        with (
+            patch("auth.get_cookie_manager", return_value=mock_cookie_manager),
+            patch("auth.restore_session_from_cookie", restore_mock),
+        ):
+            from auth import init_session_state
+
+            init_session_state()
+
+        restore_mock.assert_not_called()

--- a/tests/test_sse_broadcast.py
+++ b/tests/test_sse_broadcast.py
@@ -601,3 +601,477 @@ class _StubRoomRepo:
 
     def get_by_id(self, room_id: str) -> dict[str, Any] | None:
         return self._rows.get(room_id)
+
+
+# ---------------------------------------------------------------------------
+# publish queue-saturation paths (lines 221-231)
+# ---------------------------------------------------------------------------
+class TestPublishSaturationPaths:
+    """publish 의 QueueFull 처리 분기 — 가장 오래된 메시지 제거 / 더블 saturation."""
+
+    @pytest.mark.asyncio
+    async def test_publish_drops_oldest_when_queue_full_and_delivers_new(self):
+        """큐가 가득 차면 oldest 1건 삭제 후 새 payload 가 들어간다."""
+        from sse_broadcast import BroadcastManager
+
+        # maxsize=1 으로 만들어서 두 번째 publish 가 saturation 분기를 타게 함.
+        mgr = BroadcastManager(queue_maxsize=1)
+        q = await mgr.register_viewer("r1", "ko")
+
+        first = {"text": "first", "lang": "ko", "timestamp": 1.0}
+        second = {"text": "second", "lang": "ko", "timestamp": 2.0}
+
+        await mgr.publish("r1", "ko", first)
+        # 두 번째 publish 는 큐 가득 → get_nowait 후 put.
+        await mgr.publish("r1", "ko", second)
+
+        # get_nowait 의 결과는 second (oldest 인 first 가 빠진 뒤 second 가 들어감).
+        got = q.get_nowait()
+        assert got == second
+        # 큐는 다시 비어 있어야 한다.
+        assert q.qsize() == 0
+
+        await mgr.unregister_viewer("r1", "ko", q)
+
+    @pytest.mark.asyncio
+    async def test_publish_double_saturation_drops_message_and_logs(self, capsys):
+        """두 번째 put_nowait 도 QueueFull → 메시지 drop + 서버 로그."""
+        from sse_broadcast import BroadcastManager
+
+        mgr = BroadcastManager(queue_maxsize=1)
+        q = await mgr.register_viewer("r1", "ko")
+        # 큐를 미리 채워둠.
+        q.put_nowait({"text": "preexisting"})
+
+        # put_nowait 를 항상 QueueFull raise — 동시 producer 시뮬레이션.
+        original_put = q.put_nowait
+
+        def _always_full(_payload):
+            raise asyncio.QueueFull()
+
+        q.put_nowait = _always_full
+        # get_nowait 도 QueueEmpty 를 raise 하도록 만들어 swallow 분기를 친다.
+        original_get = q.get_nowait
+
+        def _empty(_=None):
+            raise asyncio.QueueEmpty()
+
+        q.get_nowait = _empty
+
+        try:
+            await mgr.publish("r1", "ko", {"text": "drop-me"})
+        finally:
+            q.put_nowait = original_put
+            q.get_nowait = original_get
+
+        captured = capsys.readouterr()
+        # drop 로그가 남아야 한다.
+        assert "[SSE] dropping payload" in captured.out
+        assert "viewer queue saturated" in captured.out
+
+        await mgr.unregister_viewer("r1", "ko", q)
+
+    @pytest.mark.asyncio
+    async def test_publish_recovers_when_get_raises_queue_empty(self):
+        """QueueFull 직후 get_nowait 가 QueueEmpty (race) → swallow 후 retry put."""
+        from sse_broadcast import BroadcastManager
+
+        mgr = BroadcastManager(queue_maxsize=1)
+        q = await mgr.register_viewer("r1", "ko")
+
+        # put_nowait 를 첫 호출에서만 QueueFull 을 raise, 그 다음엔 정상 동작.
+        original_put = q.put_nowait
+        call_count = {"n": 0}
+        captured_payloads = []
+
+        def _put(payload):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise asyncio.QueueFull()
+            captured_payloads.append(payload)
+            return original_put(payload)
+
+        # get_nowait 는 항상 QueueEmpty (race 시뮬레이션).
+        original_get = q.get_nowait
+
+        def _empty(_=None):
+            raise asyncio.QueueEmpty()
+
+        q.put_nowait = _put
+        q.get_nowait = _empty
+
+        try:
+            await mgr.publish("r1", "ko", {"text": "racy"})
+        finally:
+            q.put_nowait = original_put
+            q.get_nowait = original_get
+
+        # 두 번째 put 시도가 성공해 payload 가 들어갔어야 한다.
+        assert captured_payloads == [{"text": "racy"}]
+
+        await mgr.unregister_viewer("r1", "ko", q)
+
+
+# ---------------------------------------------------------------------------
+# _coerce_output_langs (lines 681-683 + parsing edges)
+# ---------------------------------------------------------------------------
+class TestCoerceOutputLangs:
+    """_coerce_output_langs — JSON / 잘못된 형식 / 빈 입력에 대한 강건성."""
+
+    def test_invalid_json_returns_fallback(self):
+        from sse_broadcast import _coerce_output_langs
+
+        assert _coerce_output_langs("not-json", "ko") == ["ko"]
+        # 잘못된 JSON 텍스트도 fallback.
+        assert _coerce_output_langs("{not-valid", "en") == ["en"]
+
+    def test_json_but_not_list_returns_fallback(self):
+        """JSON 으로 디코딩되지만 리스트가 아닌 경우 → fallback."""
+        from sse_broadcast import _coerce_output_langs
+
+        assert _coerce_output_langs('"ko"', "ko") == ["ko"]  # 문자열
+        assert _coerce_output_langs('{"key": "ko"}', "ko") == ["ko"]  # 객체
+        assert _coerce_output_langs("123", "ja") == ["ja"]  # 숫자
+
+    def test_none_returns_fallback(self):
+        from sse_broadcast import _coerce_output_langs
+
+        assert _coerce_output_langs(None, "ko") == ["ko"]
+
+    def test_empty_string_returns_fallback(self):
+        from sse_broadcast import _coerce_output_langs
+
+        # 빈 문자열은 falsy 이므로 isinstance(raw, str) and raw 를 통과 못함 →
+        # 아래 fallback 분기로 떨어진다.
+        assert _coerce_output_langs("", "ko") == ["ko"]
+
+    def test_empty_list_returns_empty_list_passthrough(self):
+        """빈 list 입력은 list 분기에서 그대로 빈 list 반환 (fallback 미사용).
+
+        주의: _coerce_output_langs 자체는 빈 list 도 그대로 통과시킨다 —
+        이는 _coerce_output_langs_list 가 fallback 을 prepend 하는 위쪽 wrapper
+        의 역할이다. 이 테스트는 두 함수의 책임 분리를 명확히 한다.
+        """
+        from sse_broadcast import _coerce_output_langs
+
+        assert _coerce_output_langs([], "ko") == []
+
+    def test_valid_json_list_returns_parsed(self):
+        from sse_broadcast import _coerce_output_langs
+
+        assert _coerce_output_langs('["ko","en","ja"]', "ko") == ["ko", "en", "ja"]
+
+    def test_filters_non_string_items(self):
+        """list 의 비-문자열 요소는 제외된다 (방어)."""
+        from sse_broadcast import _coerce_output_langs
+
+        # JSON 안에 숫자/None 이 섞여 있어도 string 만 추려낸다.
+        assert _coerce_output_langs('["ko",1,null,"en"]', "ko") == ["ko", "en"]
+
+
+class TestCoerceOutputLangsListWithFallback:
+    """_coerce_output_langs_list — fallback 을 항상 결과 안에 보존한다."""
+
+    def test_fallback_prepended_when_missing(self):
+        from sse_broadcast import _coerce_output_langs_list
+
+        # fallback 'ja' 가 결과에 없으면 맨 앞에 prepend 돼야 한다.
+        result = _coerce_output_langs_list('["ko","en"]', "ja")
+        assert result == ["ja", "ko", "en"]
+
+    def test_fallback_already_present_not_duplicated(self):
+        from sse_broadcast import _coerce_output_langs_list
+
+        result = _coerce_output_langs_list('["ko","en"]', "ko")
+        assert result == ["ko", "en"]
+
+    def test_invalid_input_returns_just_fallback(self):
+        from sse_broadcast import _coerce_output_langs_list
+
+        assert _coerce_output_langs_list(None, "ko") == ["ko"]
+        assert _coerce_output_langs_list("not-json", "ko") == ["ko"]
+
+
+# ---------------------------------------------------------------------------
+# /view/{room_id} (lines 367-399, 394-397)
+# ---------------------------------------------------------------------------
+class TestHandleView:
+    """_handle_view — repo 예외 / 룸 미존재 / 템플릿 렌더 실패 분기."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_room_returns_404_html(self):
+        from aiohttp.test_utils import TestClient, TestServer
+
+        from sse_broadcast import BroadcastManager, build_sse_app
+
+        repo = _StubRoomRepo({})
+        mgr = BroadcastManager()
+        app = build_sse_app(broadcast_manager=mgr, room_repo=repo)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/view/no-such-room")
+            assert resp.status == 404
+            text = await resp.text()
+            # RL-006: generic friendly body, no internal detail.
+            assert "Traceback" not in text
+            assert "룸을 찾을 수 없습니다" in text
+
+    @pytest.mark.asyncio
+    async def test_repo_exception_returns_404_no_leak(self):
+        """repo.get_by_id 가 raise → 404 + generic body (RL-006)."""
+        from aiohttp.test_utils import TestClient, TestServer
+
+        from sse_broadcast import BroadcastManager, build_sse_app
+
+        class ExplodingRepo:
+            def get_by_id(self, room_id):
+                raise RuntimeError("DB internal: secret/path/to/db.sqlite locked")
+
+        mgr = BroadcastManager()
+        app = build_sse_app(broadcast_manager=mgr, room_repo=ExplodingRepo())
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/view/whatever")
+            assert resp.status == 404
+            text = await resp.text()
+            # 디테일 누설 없음.
+            assert "secret/path" not in text
+            assert "RuntimeError" not in text
+            assert "Traceback" not in text
+
+    @pytest.mark.asyncio
+    async def test_template_render_failure_returns_404(self, monkeypatch):
+        """_render_viewer_html 이 raise → 404 with generic body, no traceback."""
+        from aiohttp.test_utils import TestClient, TestServer
+
+        from sse_broadcast import BroadcastManager, build_sse_app
+
+        repo = _StubRoomRepo(
+            {
+                "r1": {
+                    "id": "r1",
+                    "status": "active",
+                    "primary_output_lang": "ko",
+                    "output_langs": '["ko","en"]',
+                    "name": "Room 1",
+                }
+            }
+        )
+
+        mgr = BroadcastManager()
+        app = build_sse_app(broadcast_manager=mgr, room_repo=repo)
+
+        # _render_viewer_html 만 패치해 raise 시킴.
+        import sse_broadcast as _sb
+
+        def _explode(**_kwargs):
+            raise FileNotFoundError("template missing /secret/path/to/viewer.html")
+
+        monkeypatch.setattr(_sb, "_render_viewer_html", _explode)
+
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/view/r1")
+            assert resp.status == 404
+            text = await resp.text()
+            assert "Traceback" not in text
+            assert "secret/path" not in text
+            # generic body 가 그대로 나가야 한다.
+            assert "룸을 찾을 수 없습니다" in text
+
+
+# ---------------------------------------------------------------------------
+# _handle_health (line 265)
+# ---------------------------------------------------------------------------
+class TestHandleHealth:
+    @pytest.mark.asyncio
+    async def test_health_returns_ok(self):
+        from aiohttp.test_utils import TestClient, TestServer
+
+        from sse_broadcast import BroadcastManager, build_sse_app
+
+        repo = _StubRoomRepo({})
+        mgr = BroadcastManager()
+        app = build_sse_app(broadcast_manager=mgr, room_repo=repo)
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/health")
+            assert resp.status == 200
+            text = await resp.text()
+            assert text == "OK"
+
+
+# ---------------------------------------------------------------------------
+# channel_count (line 238)
+# ---------------------------------------------------------------------------
+class TestChannelCount:
+    @pytest.mark.asyncio
+    async def test_channel_count_reflects_registered_channels(self):
+        from sse_broadcast import BroadcastManager
+
+        mgr = BroadcastManager()
+        assert mgr.channel_count() == 0
+
+        q1 = await mgr.register_viewer("r1", "ko")
+        q2 = await mgr.register_viewer("r1", "en")
+        # 같은 room+lang 에 두 번째 viewer — channel_count 는 변하지 않음.
+        q3 = await mgr.register_viewer("r1", "ko")
+
+        assert mgr.channel_count() == 2
+
+        await mgr.unregister_viewer("r1", "ko", q1)
+        # 아직 q3 가 ko 채널에 남아 있음.
+        assert mgr.channel_count() == 2
+
+        await mgr.unregister_viewer("r1", "ko", q3)
+        # ko 채널 비어서 drop.
+        assert mgr.channel_count() == 1
+
+        await mgr.unregister_viewer("r1", "en", q2)
+        assert mgr.channel_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# run_sse_server exception handling (lines 702-720)
+# ---------------------------------------------------------------------------
+class TestRunSseServer:
+    """run_sse_server 가 모든 startup 예외를 삼키고 로그만 남기는지 검증."""
+
+    def test_app_runner_raises_does_not_propagate(self, capsys, monkeypatch):
+        """web.AppRunner 가 raise → 함수는 return, 서버 로그에 에러 기록."""
+        # web.AppRunner 자체를 패치해 인스턴스화 시 raise 하도록.
+        import sse_broadcast as _sb
+        from sse_broadcast import BroadcastManager, run_sse_server
+
+        class _ExplodingRunner:
+            def __init__(self, _app):
+                raise RuntimeError("runner cannot be created in this env")
+
+        monkeypatch.setattr(_sb.web, "AppRunner", _ExplodingRunner)
+
+        mgr = BroadcastManager()
+        repo = _StubRoomRepo({})
+
+        # 절대 raise 하면 안 됨.
+        run_sse_server(broadcast_manager=mgr, room_repo=repo, port=0)
+
+        captured = capsys.readouterr()
+        assert "[SSE] server failed to start" in captured.out
+
+    def test_event_loop_creation_failure_swallowed(self, capsys, monkeypatch):
+        """asyncio.new_event_loop 자체가 raise → 그래도 함수가 return."""
+        import sse_broadcast as _sb
+        from sse_broadcast import BroadcastManager, run_sse_server
+
+        def _fail_loop():
+            raise OSError("no event loop available")
+
+        monkeypatch.setattr(_sb.asyncio, "new_event_loop", _fail_loop)
+
+        mgr = BroadcastManager()
+        repo = _StubRoomRepo({})
+
+        run_sse_server(broadcast_manager=mgr, room_repo=repo, port=0)
+
+        captured = capsys.readouterr()
+        assert "[SSE] server failed to start" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# _translate_and_publish_secondary error paths (lines 641-661)
+# ---------------------------------------------------------------------------
+class TestTranslateAndPublishSecondary:
+    """_translate_and_publish_secondary — translate_fn / publish 예외 격리 검증."""
+
+    @pytest.mark.asyncio
+    async def test_translate_fn_raises_swallowed_no_publish(self, capsys):
+        """translate_fn 이 raise → 로그 후 publish 미호출, 함수는 return."""
+        from sse_broadcast import BroadcastManager, _translate_and_publish_secondary
+
+        mgr = BroadcastManager()
+        q = await mgr.register_viewer("r1", "en")
+
+        async def _failing_translate(text, src, dst):
+            raise RuntimeError("bedrock down")
+
+        # 절대 raise 하면 안 됨.
+        await _translate_and_publish_secondary(
+            mgr,
+            "r1",
+            source_text="hi",
+            source_lang="en",
+            target_lang="en",
+            translate_fn=_failing_translate,
+        )
+
+        captured = capsys.readouterr()
+        assert "[SSE] secondary translate failed" in captured.out
+        # 큐에는 아무것도 들어가지 않았어야 한다.
+        assert q.qsize() == 0
+        await mgr.unregister_viewer("r1", "en", q)
+
+    @pytest.mark.asyncio
+    async def test_translate_fn_returns_falsy_skips_publish(self):
+        """translate_fn 이 None / 빈 문자열 → publish 미호출."""
+        from sse_broadcast import BroadcastManager, _translate_and_publish_secondary
+
+        mgr = BroadcastManager()
+        q = await mgr.register_viewer("r1", "en")
+
+        async def _translate_returns_none(text, src, dst):
+            return None
+
+        await _translate_and_publish_secondary(
+            mgr,
+            "r1",
+            source_text="hi",
+            source_lang="en",
+            target_lang="en",
+            translate_fn=_translate_returns_none,
+        )
+
+        # publish 가 호출되지 않았으므로 큐는 비어 있다.
+        assert q.qsize() == 0
+
+        # 빈 문자열 케이스도 동일.
+        async def _translate_returns_empty(text, src, dst):
+            return ""
+
+        await _translate_and_publish_secondary(
+            mgr,
+            "r1",
+            source_text="hi",
+            source_lang="en",
+            target_lang="en",
+            translate_fn=_translate_returns_empty,
+        )
+        assert q.qsize() == 0
+
+        await mgr.unregister_viewer("r1", "en", q)
+
+    @pytest.mark.asyncio
+    async def test_publish_raises_swallowed_in_background_task(
+        self, capsys, monkeypatch
+    ):
+        """manager.publish 가 raise → 로그만, 함수는 raise 하지 않음."""
+        from sse_broadcast import BroadcastManager, _translate_and_publish_secondary
+
+        mgr = BroadcastManager()
+
+        async def _publish_explodes(*_args, **_kwargs):
+            raise RuntimeError("publish boom")
+
+        # publish 만 패치.
+        monkeypatch.setattr(mgr, "publish", _publish_explodes)
+
+        async def _translate_ok(text, src, dst):
+            return f"[{dst}]{text}"
+
+        # 절대 raise 하면 안 됨.
+        await _translate_and_publish_secondary(
+            mgr,
+            "r1",
+            source_text="hi",
+            source_lang="en",
+            target_lang="ja",
+            translate_fn=_translate_ok,
+        )
+
+        captured = capsys.readouterr()
+        assert "[SSE] secondary publish failed" in captured.out

--- a/tests/test_websocket_auth.py
+++ b/tests/test_websocket_auth.py
@@ -358,3 +358,160 @@ class TestAuthenticateClientLanguageSettings:
         assert result is not None
         assert result["language_settings"]["input_lang"] == "ja"
         assert result["language_settings"]["output_lang"] == "ko"
+
+
+# ============================================================
+# Room handling branches in _authenticate_client (lines 189-228)
+# ============================================================
+class TestAuthenticateClientRoomHandling:
+    """requested_room_id 분기 — repo 예외 / closed / 메모리 race 시나리오 검증."""
+
+    def _make_ws_with_room(self, mock_db, room_id):
+        """testuser 자격으로 특정 room_id 요청하는 auth 메시지를 보내는 ws."""
+        from unittest.mock import AsyncMock
+
+        db_user = mock_db.get_user_by_username("testuser")
+        return (
+            _make_websocket(
+                {
+                    "type": "auth",
+                    "user": {
+                        "id": db_user["id"],
+                        "username": "testuser",
+                        "role": "user",
+                    },
+                    "room_id": room_id,
+                }
+            ),
+            AsyncMock(),
+        )
+
+    def test_unknown_room_id_rejected_with_generic_message(self, mock_db, capsys):
+        """존재하지 않는 room_id → auth_error '요청한 룸을 찾을 수 없습니다.' (RL-006).
+
+        room_repo 가 없는 RoomManager 의 기본 in-memory 모드 → get_room()=None →
+        room_closed 분기로 가서 거절된다.
+        """
+        from room_manager import RoomManager
+        from websocket_handler import _authenticate_client
+
+        ws, _ = self._make_ws_with_room(mock_db, "no-such-room")
+
+        # repo 가 없는 빈 RoomManager.
+        empty_mgr = RoomManager()
+
+        with (
+            patch("websocket_handler.get_user_model", return_value=mock_db),
+            patch("websocket_handler._room_manager", empty_mgr),
+        ):
+            result = asyncio.run(_authenticate_client(ws))
+
+        assert result is None
+        sent = _get_sent_messages(ws)
+        # RL-006: 응답에 내부 디테일 누설 없음.
+        auth_errors = [m for m in sent if m.get("type") == "auth_error"]
+        assert len(auth_errors) == 1
+        assert auth_errors[0]["message"] == "요청한 룸을 찾을 수 없습니다."
+
+    def test_repo_exception_treated_as_room_closed(self, mock_db, capsys):
+        """repo.get_by_id 가 raise → room_closed=True 로 fail-closed 처리."""
+        from room_manager import RoomManager
+        from websocket_handler import _authenticate_client
+
+        ws, _ = self._make_ws_with_room(mock_db, "r1")
+
+        # 메모리에는 룸이 있지만 DB 조회는 실패하는 시나리오.
+        class _ExplodingRepo:
+            def get_by_id(self, room_id):
+                raise RuntimeError("DB internal: locked")
+
+            # RoomManager 의 hydrate_from_db 가 호출하는 다른 메서드는 없어야 함.
+
+        mgr = RoomManager(room_repository=_ExplodingRepo())
+        # 메모리에 r1 을 직접 넣어 get_room("r1") 가 not None 이 되게 한다.
+        from room_manager import RoomState
+
+        mgr._rooms["r1"] = RoomState(room_id="r1")
+
+        with (
+            patch("websocket_handler.get_user_model", return_value=mock_db),
+            patch("websocket_handler._room_manager", mgr),
+        ):
+            result = asyncio.run(_authenticate_client(ws))
+
+        assert result is None
+        captured = capsys.readouterr()
+        # 내부 에러는 서버 로그로 남아야 한다.
+        assert "[Auth] 룸 상태 조회 실패" in captured.out
+
+        sent = _get_sent_messages(ws)
+        auth_errors = [m for m in sent if m.get("type") == "auth_error"]
+        assert len(auth_errors) == 1
+        # RL-006: generic message — 'DB internal' 같은 디테일이 절대 새면 안 됨.
+        assert "DB internal" not in auth_errors[0]["message"]
+        assert auth_errors[0]["message"] == "요청한 룸을 찾을 수 없습니다."
+
+    def test_closed_room_status_rejected(self, mock_db):
+        """persisted.status == 'closed' → auth_error 거절."""
+        from room_manager import RoomManager, RoomState
+        from websocket_handler import _authenticate_client
+
+        ws, _ = self._make_ws_with_room(mock_db, "closed-room")
+
+        class _ClosedRepo:
+            def get_by_id(self, room_id):
+                # 영속화된 상태가 closed 임을 시뮬레이트.
+                return {"id": room_id, "status": "closed"}
+
+        mgr = RoomManager(room_repository=_ClosedRepo())
+        mgr._rooms["closed-room"] = RoomState(room_id="closed-room")
+
+        with (
+            patch("websocket_handler.get_user_model", return_value=mock_db),
+            patch("websocket_handler._room_manager", mgr),
+        ):
+            result = asyncio.run(_authenticate_client(ws))
+
+        assert result is None
+        sent = _get_sent_messages(ws)
+        auth_errors = [m for m in sent if m.get("type") == "auth_error"]
+        assert len(auth_errors) == 1
+        assert auth_errors[0]["message"] == "요청한 룸을 찾을 수 없습니다."
+
+    def test_register_connection_keyerror_race_returns_auth_error(self, mock_db):
+        """register_connection 이 KeyError → race 분기로 generic 거절."""
+        from room_manager import RoomManager, RoomState
+        from websocket_handler import _authenticate_client
+
+        ws, _ = self._make_ws_with_room(mock_db, "r1")
+
+        class _GoodRepo:
+            def get_by_id(self, room_id):
+                return {"id": room_id, "status": "active"}
+
+        mgr = RoomManager(room_repository=_GoodRepo())
+        mgr._rooms["r1"] = RoomState(room_id="r1")
+
+        # register_connection 이 KeyError 를 raise 하도록 패치.
+        original_register = mgr.register_connection
+
+        def _raising_register(room_id, websocket):
+            # 메모리에서 이미 삭제됐다고 가정.
+            raise KeyError(room_id)
+
+        mgr.register_connection = _raising_register
+
+        try:
+            with (
+                patch("websocket_handler.get_user_model", return_value=mock_db),
+                patch("websocket_handler._room_manager", mgr),
+            ):
+                result = asyncio.run(_authenticate_client(ws))
+        finally:
+            mgr.register_connection = original_register
+
+        assert result is None
+        sent = _get_sent_messages(ws)
+        auth_errors = [m for m in sent if m.get("type") == "auth_error"]
+        assert len(auth_errors) == 1
+        assert auth_errors[0]["message"] == "요청한 룸을 찾을 수 없습니다."

--- a/tests/test_websocket_handler.py
+++ b/tests/test_websocket_handler.py
@@ -739,3 +739,545 @@ class TestHandleTranscriptLanguageSettings:
         sent = _get_sent_messages(ws)
         assert sent[0]["source_language"] == "en"
         assert sent[0]["target_language"] == "ko"
+
+
+# ============================================================
+# _handle_session_request 에러 분기 (lines 624-632) — RL-006
+# ============================================================
+class TestHandleSessionRequest:
+    """_handle_session_request 의 성공/예외 분기 검증."""
+
+    def test_success_sends_openai_session(self):
+        """create_openai_session 성공 → openai_session 메시지 전송."""
+        from websocket_handler import _handle_session_request
+
+        ws = _make_websocket()
+
+        async def fake_create():
+            return {"id": "sess-1", "client_secret": "abc"}
+
+        with patch(
+            "websocket_handler.create_openai_session",
+            side_effect=fake_create,
+        ):
+            asyncio.run(_handle_session_request(ws))
+
+        sent = _get_sent_messages(ws)
+        assert len(sent) == 1
+        assert sent[0]["type"] == "openai_session"
+        assert sent[0]["session"] == {"id": "sess-1", "client_secret": "abc"}
+
+    def test_create_session_raises_sends_error_message(self):
+        """create_openai_session 가 raise 하면 error 메시지가 전송된다.
+
+        Note: 현재 구현은 RL-006 위반 — error.message 가 ``str(e)`` 를 echo 한다.
+        이 테스트는 실제 동작 (메시지 전송 + 메시지 type=error) 만 단언한다.
+        """
+        from websocket_handler import _handle_session_request
+
+        ws = _make_websocket()
+
+        async def fake_fail():
+            raise RuntimeError("OpenAI API 503")
+
+        with patch(
+            "websocket_handler.create_openai_session",
+            side_effect=fake_fail,
+        ):
+            asyncio.run(_handle_session_request(ws))
+
+        sent = _get_sent_messages(ws)
+        assert len(sent) == 1
+        assert sent[0]["type"] == "error"
+        # 메시지에 "OpenAI 세션 생성 실패" 라는 도메인 prefix 가 포함돼야 한다.
+        assert "OpenAI 세션 생성 실패" in sent[0]["message"]
+
+
+# ============================================================
+# handle_openai_websocket: 메시지 처리 예외 / 정리 (lines 770-792)
+# ============================================================
+class TestHandleOpenaiWebsocketErrorPaths:
+    """handle_openai_websocket 의 외부/내부 예외 분기 + finally 정리 검증."""
+
+    def _make_iterable_ws(self, messages):
+        """주어진 list[str|Exception] 을 한 번씩 yield 하는 async websocket mock.
+
+        Exception 인스턴스는 raise 해서 message-loop 내부 try 의 except 분기를
+        검증할 수 있게 한다. ``__aiter__`` 는 sync 로 self 를 반환하고 ``__anext__``
+        만 coroutine 인 형태 — 기존 test_websocket_handler 에서 사용하는 패턴.
+        """
+        ws = AsyncMock()
+        ws.remote_address = ("127.0.0.1", 12345)
+        ws.send = AsyncMock()
+        ws.recv = AsyncMock()
+        ws.close = AsyncMock()
+
+        idx = {"i": 0}
+
+        async def _anext(self_):
+            i = idx["i"]
+            idx["i"] += 1
+            if i >= len(messages):
+                raise StopAsyncIteration
+            m = messages[i]
+            if isinstance(m, BaseException):
+                raise m
+            return m
+
+        ws.__aiter__ = lambda self_: self_
+        ws.__anext__ = _anext
+        return ws
+
+    def test_per_message_exception_sends_generic_error_message(self, mock_db):
+        """메시지 처리 중 예외 → generic 메시지 (RL-006: str(e) echo 금지)."""
+        from websocket_handler import handle_openai_websocket
+
+        # transcript 메시지를 보내고, _handle_transcript 가 raise 하도록 함.
+        ws = self._make_iterable_ws([json.dumps({"type": "transcript", "text": "hi"})])
+        mock_user = {
+            "id": 1,
+            "username": "testuser",
+            "role": "user",
+            "is_active": True,
+            "language_settings": {"input_lang": "auto", "output_lang": "ko"},
+            "room_id": None,
+        }
+        mock_auth = AsyncMock(return_value=mock_user)
+
+        with (
+            patch("websocket_handler._authenticate_client", new=mock_auth),
+            patch(
+                "websocket_handler._init_translation_clients",
+                return_value=(MagicMock(), MagicMock(), True),
+            ),
+            patch(
+                "websocket_handler._handle_transcript",
+                side_effect=RuntimeError("internal/secret/path leaked"),
+            ),
+        ):
+            asyncio.run(handle_openai_websocket(ws))
+
+        sent = _get_sent_messages(ws)
+        # connection + error 메시지가 모두 있어야 한다.
+        types = [m.get("type") for m in sent]
+        assert "connection" in types
+        assert "error" in types
+
+        error_msg = next(m for m in sent if m.get("type") == "error")
+        # RL-006: 내부 예외 텍스트가 절대 새어 나가서는 안 된다.
+        assert "secret/path" not in error_msg["message"]
+        assert "RuntimeError" not in error_msg["message"]
+        # 우리 generic 메시지여야 한다.
+        assert error_msg["message"] == "메시지 처리 중 오류가 발생했습니다."
+
+    def test_outer_exception_during_message_loop_logs_and_cleans_up(self, capsys):
+        """메시지 루프 내부에서 raise 가 try 의 outer except 까지 도달하는 케이스.
+
+        - _init_translation_clients 가 raise → outer except → 서버 로그.
+        - finally 블록에서 unregister_connection 이 (room_id 가 있다면) 호출된다.
+        """
+        from websocket_handler import handle_openai_websocket
+
+        ws = self._make_iterable_ws([])
+        mock_user = {
+            "id": 1,
+            "username": "alice",
+            "role": "user",
+            "is_active": True,
+            "language_settings": {"input_lang": "auto", "output_lang": "ko"},
+            "room_id": "room-zombie",
+        }
+        mock_auth = AsyncMock(return_value=mock_user)
+
+        # RoomManager 의 unregister_connection 이 정상 동작하는지 확인.
+        mock_room_mgr = MagicMock()
+        mock_room_mgr.unregister_connection = MagicMock()
+
+        with (
+            patch("websocket_handler._authenticate_client", new=mock_auth),
+            patch(
+                "websocket_handler._init_translation_clients",
+                side_effect=RuntimeError("aws creds missing"),
+            ),
+            patch("websocket_handler._room_manager", mock_room_mgr),
+        ):
+            asyncio.run(handle_openai_websocket(ws))
+
+        # outer except 가 서버에 로깅 — RL-006 (서버에는 디테일 OK).
+        captured = capsys.readouterr()
+        assert "[WebSocket] 연결 오류" in captured.out
+        # finally: room_id 가 있으니 unregister 가 호출돼야 한다.
+        mock_room_mgr.unregister_connection.assert_called_once_with("room-zombie", ws)
+
+    def test_finally_cleanup_swallows_unregister_exceptions(self, capsys):
+        """unregister_connection 이 raise 해도 핸들러 자체는 raise 하지 않는다.
+
+        대신 [Room] 연결 해제 실패 로그가 남아야 한다 (RL-006).
+        """
+        from websocket_handler import handle_openai_websocket
+
+        ws = self._make_iterable_ws([])
+        mock_user = {
+            "id": 1,
+            "username": "alice",
+            "role": "user",
+            "is_active": True,
+            "language_settings": {"input_lang": "auto", "output_lang": "ko"},
+            "room_id": "room-1",
+        }
+        mock_auth = AsyncMock(return_value=mock_user)
+
+        mock_room_mgr = MagicMock()
+        mock_room_mgr.unregister_connection.side_effect = RuntimeError("repo down")
+
+        with (
+            patch("websocket_handler._authenticate_client", new=mock_auth),
+            patch(
+                "websocket_handler._init_translation_clients",
+                return_value=(MagicMock(), MagicMock(), True),
+            ),
+            patch("websocket_handler._room_manager", mock_room_mgr),
+        ):
+            # 절대 raise 해서는 안 됨.
+            asyncio.run(handle_openai_websocket(ws))
+
+        captured = capsys.readouterr()
+        assert "[Room] 연결 해제 실패" in captured.out
+
+    def test_finally_skips_unregister_when_no_user_info(self):
+        """user_info 가 None 이면 finally 의 unregister 분기를 건너뛴다."""
+        from websocket_handler import handle_openai_websocket
+
+        ws = self._make_iterable_ws([])
+        # auth 가 실패해 None 반환.
+        mock_auth = AsyncMock(return_value=None)
+
+        mock_room_mgr = MagicMock()
+
+        with (
+            patch("websocket_handler._authenticate_client", new=mock_auth),
+            patch(
+                "websocket_handler._init_translation_clients",
+                return_value=(MagicMock(), MagicMock(), True),
+            ),
+            patch("websocket_handler._room_manager", mock_room_mgr),
+        ):
+            asyncio.run(handle_openai_websocket(ws))
+
+        # 인증 실패면 unregister 가 호출되면 안 된다.
+        mock_room_mgr.unregister_connection.assert_not_called()
+
+    def test_finally_skips_unregister_when_room_id_missing(self):
+        """user_info 는 있지만 room_id 가 falsy → unregister 호출 안 함."""
+        from websocket_handler import handle_openai_websocket
+
+        ws = self._make_iterable_ws([])
+        mock_user = {
+            "id": 1,
+            "username": "alice",
+            "role": "user",
+            "is_active": True,
+            "language_settings": {"input_lang": "auto", "output_lang": "ko"},
+            # room_id 없음.
+        }
+        mock_auth = AsyncMock(return_value=mock_user)
+
+        mock_room_mgr = MagicMock()
+
+        with (
+            patch("websocket_handler._authenticate_client", new=mock_auth),
+            patch(
+                "websocket_handler._init_translation_clients",
+                return_value=(MagicMock(), MagicMock(), True),
+            ),
+            patch("websocket_handler._room_manager", mock_room_mgr),
+        ):
+            asyncio.run(handle_openai_websocket(ws))
+
+        mock_room_mgr.unregister_connection.assert_not_called()
+
+
+# ============================================================
+# _periodic_room_cleanup_loop (lines 801-822)
+# ============================================================
+class TestPeriodicRoomCleanupLoop:
+    """_periodic_room_cleanup_loop 의 분기 검증.
+
+    asyncio.sleep 을 monkey-patch 해 즉시 다음 사이클로 진입시키고,
+    task.cancel() 로 루프를 종료하는 패턴을 사용한다.
+    """
+
+    def test_repo_none_skips_cleanup_continues_loop(self):
+        """_room_manager._repo == None → 한 사이클 그냥 continue 한 뒤 cancel."""
+
+        async def runner():
+            from websocket_handler import _periodic_room_cleanup_loop
+
+            mock_room_mgr = MagicMock()
+            mock_room_mgr._repo = None
+
+            sleep_calls = {"n": 0}
+
+            async def _fake_sleep(_seconds):
+                # 첫 sleep 만 통과시키고, 두 번째 sleep 에서 raise CancelledError.
+                sleep_calls["n"] += 1
+                if sleep_calls["n"] >= 2:
+                    raise asyncio.CancelledError()
+
+            with (
+                patch("websocket_handler._room_manager", mock_room_mgr),
+                patch("websocket_handler.asyncio.sleep", new=_fake_sleep),
+            ):
+                with pytest.raises(asyncio.CancelledError):
+                    await _periodic_room_cleanup_loop()
+
+            return sleep_calls["n"]
+
+        n = asyncio.run(runner())
+        # 최소 2번 sleep 이 호출됐다 (첫 사이클 + 두 번째 cancel).
+        assert n == 2
+
+    def test_cleanup_returns_room_ids_calls_delete_room_for_each(self):
+        """cleanup_stale_rooms 가 ['z1','z2'] → delete_room 가 정확히 두 번 호출."""
+
+        async def runner():
+            from websocket_handler import _periodic_room_cleanup_loop
+
+            mock_repo = MagicMock()
+            # 첫 사이클에 두 개 반환, 이후엔 빈 리스트.
+            mock_repo.cleanup_stale_rooms.side_effect = [["z1", "z2"], []]
+
+            mock_room_mgr = MagicMock()
+            mock_room_mgr._repo = mock_repo
+
+            sleep_calls = {"n": 0}
+
+            async def _fake_sleep(_seconds):
+                sleep_calls["n"] += 1
+                if sleep_calls["n"] >= 2:
+                    raise asyncio.CancelledError()
+
+            with (
+                patch("websocket_handler._room_manager", mock_room_mgr),
+                patch("websocket_handler.asyncio.sleep", new=_fake_sleep),
+            ):
+                with pytest.raises(asyncio.CancelledError):
+                    await _periodic_room_cleanup_loop()
+
+            return mock_room_mgr.delete_room.call_args_list
+
+        delete_calls = asyncio.run(runner())
+        # 정확히 두 룸이 delete 됐어야 한다 (RL-004: exact equality).
+        assert [c.args[0] for c in delete_calls] == ["z1", "z2"]
+
+    def test_cleanup_raises_loop_continues_until_cancelled(self, capsys):
+        """cleanup_stale_rooms 가 raise → 로그 후 루프 계속 (실패 격리)."""
+
+        async def runner():
+            from websocket_handler import _periodic_room_cleanup_loop
+
+            mock_repo = MagicMock()
+            mock_repo.cleanup_stale_rooms.side_effect = RuntimeError("db locked")
+
+            mock_room_mgr = MagicMock()
+            mock_room_mgr._repo = mock_repo
+
+            sleep_calls = {"n": 0}
+
+            async def _fake_sleep(_seconds):
+                sleep_calls["n"] += 1
+                # 두 번 cleanup 실패를 허용하고 세 번째에 cancel.
+                if sleep_calls["n"] >= 3:
+                    raise asyncio.CancelledError()
+
+            with (
+                patch("websocket_handler._room_manager", mock_room_mgr),
+                patch("websocket_handler.asyncio.sleep", new=_fake_sleep),
+            ):
+                with pytest.raises(asyncio.CancelledError):
+                    await _periodic_room_cleanup_loop()
+
+            return mock_repo.cleanup_stale_rooms.call_count
+
+        call_count = asyncio.run(runner())
+        # 최소 2번 cleanup 가 시도됐어야 한다 — 한 번의 raise 가 루프를 죽이면 안 됨.
+        assert call_count == 2
+        captured = capsys.readouterr()
+        assert "[Room] cleanup loop error" in captured.out
+
+    def test_cancellation_propagates_cleanly(self):
+        """CancelledError 는 except 에서 잡히지 않고 전파돼야 한다."""
+
+        async def runner():
+            from websocket_handler import _periodic_room_cleanup_loop
+
+            mock_repo = MagicMock()
+            mock_repo.cleanup_stale_rooms.return_value = []
+
+            mock_room_mgr = MagicMock()
+            mock_room_mgr._repo = mock_repo
+
+            async def _fake_sleep(_seconds):
+                raise asyncio.CancelledError()
+
+            with (
+                patch("websocket_handler._room_manager", mock_room_mgr),
+                patch("websocket_handler.asyncio.sleep", new=_fake_sleep),
+            ):
+                # CancelledError 가 그대로 bubble up.
+                with pytest.raises(asyncio.CancelledError):
+                    await _periodic_room_cleanup_loop()
+
+        asyncio.run(runner())
+
+
+# ============================================================
+# Module-level singletons & accessors (lines 47, 52, 64)
+# ============================================================
+class TestModuleSingletons:
+    """get_room_manager / get_broadcast_manager / attach_broadcast_metrics_repo."""
+
+    def test_get_room_manager_returns_module_singleton(self):
+        from websocket_handler import _room_manager, get_room_manager
+
+        assert get_room_manager() is _room_manager
+
+    def test_get_broadcast_manager_returns_module_singleton(self):
+        from websocket_handler import _broadcast_manager, get_broadcast_manager
+
+        assert get_broadcast_manager() is _broadcast_manager
+
+    def test_attach_broadcast_metrics_repo_wires_repo_into_manager(self):
+        """attach_broadcast_metrics_repo 가 BroadcastManager 의 _metrics_repo 를 set."""
+        from websocket_handler import (
+            _broadcast_manager,
+            attach_broadcast_metrics_repo,
+        )
+
+        sentinel_repo = MagicMock()
+        original = _broadcast_manager._metrics_repo
+        try:
+            attach_broadcast_metrics_repo(sentinel_repo)
+            assert _broadcast_manager._metrics_repo is sentinel_repo
+        finally:
+            # 다른 테스트에 영향이 없도록 원복.
+            _broadcast_manager._metrics_repo = original
+
+
+# ============================================================
+# _translate_secondary (lines 624-632)
+# ============================================================
+class TestTranslateSecondary:
+    """_translate_secondary 는 _translate_text 를 호출해 첫 번째 값(번역문)만 반환."""
+
+    def test_returns_translated_text_from_translate_text(self):
+        """_translate_text 가 (text, used_llm) 튜플 → 첫 요소 반환."""
+        from websocket_handler import _translate_secondary
+
+        translate_client = MagicMock()
+        bedrock_client = MagicMock()
+
+        with patch(
+            "websocket_handler._translate_text",
+            return_value=("Hello", True),
+        ) as mock_tt:
+            result = _translate_secondary(
+                "안녕",
+                "ko",
+                "en",
+                translate_client,
+                bedrock_client,
+                bedrock_available=True,
+            )
+
+        assert result == "Hello"
+        mock_tt.assert_called_once_with(
+            "안녕",
+            "ko",
+            "en",
+            translate_client,
+            bedrock_client,
+            True,
+        )
+
+    def test_returns_none_when_translate_text_returns_none(self):
+        """_translate_text 가 (None, False) 를 반환하면 None 통과."""
+        from websocket_handler import _translate_secondary
+
+        with patch(
+            "websocket_handler._translate_text",
+            return_value=(None, False),
+        ):
+            result = _translate_secondary(
+                "hi",
+                "en",
+                "ko",
+                MagicMock(),
+                None,
+                bedrock_available=False,
+            )
+
+        assert result is None
+
+
+# ============================================================
+# language_update inside handle_openai_websocket (lines 727-744)
+# ============================================================
+class TestLanguageUpdateHandling:
+    """language_update 메시지로 connection 의 language_settings 가 갱신된다."""
+
+    def test_language_update_message_emits_language_updated_response(self):
+        """language_update 메시지 → language_updated 응답이 송신된다."""
+        from websocket_handler import handle_openai_websocket
+
+        ws = AsyncMock()
+        ws.remote_address = ("127.0.0.1", 12345)
+        ws.send = AsyncMock()
+
+        # 한 번의 language_update 메시지를 yield 하는 async iterator.
+        idx = {"i": 0}
+
+        async def _anext(self_):
+            i = idx["i"]
+            idx["i"] += 1
+            if i == 0:
+                return json.dumps(
+                    {
+                        "type": "language_update",
+                        "input_lang": "en",
+                        "output_lang": "ja",
+                    }
+                )
+            raise StopAsyncIteration
+
+        ws.__aiter__ = lambda self_: self_
+        ws.__anext__ = _anext
+
+        mock_user = {
+            "id": 1,
+            "username": "alice",
+            "role": "user",
+            "is_active": True,
+            "language_settings": {"input_lang": "auto", "output_lang": "ko"},
+            "room_id": None,
+        }
+
+        with (
+            patch(
+                "websocket_handler._authenticate_client",
+                new=AsyncMock(return_value=mock_user),
+            ),
+            patch(
+                "websocket_handler._init_translation_clients",
+                return_value=(MagicMock(), MagicMock(), True),
+            ),
+        ):
+            asyncio.run(handle_openai_websocket(ws))
+
+        sent = _get_sent_messages(ws)
+        # connection 메시지 + language_updated 메시지가 있어야 한다.
+        types = [m.get("type") for m in sent]
+        assert "language_updated" in types
+        updated = next(m for m in sent if m["type"] == "language_updated")
+        assert updated["input_lang"] == "en"
+        assert updated["output_lang"] == "ja"


### PR DESCRIPTION
Closes #72

## Summary
+72 tests covering the highest-ROI uncovered branches in auth.py, websocket_handler.py, sse_broadcast.py.

## Coverage delta

| File | Before | After | Δ |
|---|---|---|---|
| auth.py | 69% | 98% | +29 |
| websocket_handler.py | 75% | 86% | +11 |
| sse_broadcast.py | 79% | 92% | +13 |
| **TOTAL** | **84%** | **92.10%** | **+8** |

## Tests added

| File | New tests |
|---|---|
| \`tests/test_auth_streamlit_ui.py\` (new) | 31 |
| \`tests/test_websocket_handler.py\` (extended) | 17 |
| \`tests/test_websocket_auth.py\` (extended) | 4 |
| \`tests/test_sse_broadcast.py\` (extended) | 20 |

## Branch coverage highlights
- **auth**: check_usage_limit Streamlit-context (admin/regular/None remaining/raises), display_user_info early return + full_name branches, display_login_form auth/unauth/empty/submit/valid/invalid, init_session_state restore-once invariant, get_session_cookie + get_cookie_manager raise fallbacks, update_user_session id mismatch.
- **websocket_handler**: _handle_session_request happy + error, handle_openai_websocket per-message generic error (RL-006), outer except, finally unregister with try/except, _periodic_room_cleanup_loop (None repo / rooms returned / raise / cancel), _authenticate_client unknown/closed/repo-raise paths, module accessors (\`get_room_manager\`, \`get_broadcast_manager\`, \`attach_broadcast_metrics_repo\`).
- **sse_broadcast**: publish drop-oldest + double-saturation logging + QueueEmpty race, _coerce_output_langs invalid JSON / not-list / None / empty / valid / non-string filter, _handle_view repo-raise / template-fail (both → 404 generic, RL-006), run_sse_server AppRunner-raises swallow, _translate_and_publish_secondary translate-raise / None-result / publish-raise.

## Verification
\`\`\`
655 passed, 22 deselected, 40 warnings in 71s
TOTAL coverage: 92.10% (gate 50%)
\`\`\`
- ruff clean
- black clean

## Findings (out of scope)
- **Pre-existing RL-006 leak** in \`websocket_handler._handle_session_request\` (line ~295): \`f"OpenAI 세션 생성 실패: {e!s}"\` echoes raw str(e) to client. The new test \`TestHandleSessionRequest.test_create_session_raises_sends_error_message\` asserts the current behavior (so the test passes); fixing the leak is a separate change. This was already noted in sprint Discovered Issues.

## Test plan
- [x] All 72 new tests pass
- [x] No regression in 583 pre-existing tests
- [x] Coverage gate (50%) satisfied at 92.10%
- [x] Lint + format clean
- [ ] CI green (validate after push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)