### PR TITLE
fix(translation): refresh retired Bedrock Claude model IDs

### DIFF
--- a/translation.py
+++ b/translation.py
@@ -18,11 +18,19 @@ SOURCE_LANG_NAMES = {
     "de": "독일어",
 }
 
-# Bedrock 모델 ID (안정성 순서)
+# Bedrock 모델 ID (품질 → 속도 순, 앞이 실패하면 뒤로 폴백)
+#
+# 이전 목록(claude-3-5-sonnet-20240620, claude-3-haiku-20240307,
+# claude-3-sonnet-20240229) 은 전부 Anthropic 직접 API 에서 이미 은퇴
+# (2025-10~2026-04) 했고 Bedrock 도 2026-03-01 부터 순차 종료. 지금 호출은
+# 조용히 실패해서 Amazon Translate 폴백만 남는다.
+#
+# 리전 프리픽스 `us.` 는 US 크로스 리전 inference profile. AWS_REGION 이
+# us-* 가 아닌 배포에서는 `eu.` 등 로컬 프리픽스로 교체하거나 프리픽스
+# 없는 direct model ID 를 시도하도록 오퍼레이터가 조정해야 한다.
 BEDROCK_MODEL_IDS = [
-    "anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "anthropic.claude-3-haiku-20240307-v1:0",
-    "anthropic.claude-3-sonnet-20240229-v1:0",
+    "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "us.anthropic.claude-haiku-4-5-20251001-v1:0",
 ]
 
 


### PR DESCRIPTION
Closes #76

## 요약

\`translation.py:BEDROCK_MODEL_IDS\` 폴백 체인의 세 모델이 모두 은퇴 상태 — LLM 우선 번역이 조용히 죽어 Amazon Translate 폴백만 살아있는 상태를 정리합니다.

## Before / After

**Before** — 셋 다 은퇴:
\`\`\`python
BEDROCK_MODEL_IDS = [
    \"anthropic.claude-3-5-sonnet-20240620-v1:0\",  # 2025-10-28 은퇴 (Bedrock 2026-03-01 종료)
    \"anthropic.claude-3-haiku-20240307-v1:0\",     # 2026-04-20 은퇴, Bedrock Legacy
    \"anthropic.claude-3-sonnet-20240229-v1:0\",    # 2025-07-21 은퇴
]
\`\`\`

**After** — 현재 활성 두 모델:
\`\`\`python
BEDROCK_MODEL_IDS = [
    \"us.anthropic.claude-sonnet-4-5-20250929-v1:0\",   # quality-first
    \"us.anthropic.claude-haiku-4-5-20251001-v1:0\",    # latency fallback
]
\`\`\`

## 근거

Anthropic 공식 [Model Deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations) 페이지에서 세 모델 모두 \`Retired\` 상태 확인. Bedrock 은 [자체 스케줄](https://docs.aws.amazon.com/bedrock/latest/userguide/model-lifecycle.html) 로 운영되지만 3.5 Sonnet v1 은 이미 US/EU 종료(2026-03-01, 4개월 전) 상태.

## 왜 폴백만 있으니 지금 잘 돌아 보이나

\`websocket_handler.py:_translate_text\` 가 Bedrock 실패 시 Amazon Translate 로 우아하게 폴백하도록 되어 있어 catastrophic 실패는 안 남. 대신 이 저장소가 자랑하는 \"LLM 우선 컨텍스트 번역\" 품질 축이 조용히 무너져 있음.

## Test plan

- [x] \`uv run pytest -q\` — **655 passed, 92.10%**
- [ ] Bedrock 콘솔에서 \`us.anthropic.claude-sonnet-4-5-*\` / \`us.anthropic.claude-haiku-4-5-*\` access 활성화 확인 (계정별 opt-in)
- [ ] 배포 후 실제 발화로 LLM 번역 응답 로그 확인 (\`[Translation] ✅\` prefix)

## 지역 배포 주의

프리픽스 \`us.\` 는 US 크로스 리전 inference profile. \`AWS_REGION\` 이 \`us-*\` 가 아닌 배포는:
- \`eu.\` / \`ap.\` 등으로 교체, 또는
- 프리픽스 없는 \`anthropic.*\` direct model ID 사용 (리전에서 직접 지원할 때만)

## 관계

**PR #75 (OpenAI GA 마이그레이션) 와 독립.** 배포 순서는 무관 (같은 파일 안 만짐). 별도로 리뷰/머지 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)