### PR TITLE
fix(webrtc): 실브라우저 블로커 4건 — GA SDP 엔드포인트/WS 포트 고정/정리 경로/QR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ docker run --rm -p 8501:8501 -p 8765:8765 -p 8766:8766 \
 - `AWS_ACCESS_KEY_ID`: Required for AWS service authentication (server-side only)
 - `AWS_SECRET_ACCESS_KEY`: Required for AWS service authentication (server-side only)
 - `AWS_REGION`: Optional, defaults to `ap-northeast-2` (Seoul). Bedrock translation uses `global.` cross-region inference profiles (translation.py), which are callable from any commercial region — Seoul has no `apac.` profile for the Claude 4.5 generation, so the `global.` prefix is required there.
+- `WS_PORT`: Optional, defaults to `8765`. Fixed TCP port for the translation-pipeline WebSocket server (process-wide singleton). Must match the Docker port mapping — dynamic per-session allocation leaked past the mapping (#84).
 - `SSE_PORT`: Optional, defaults to `8766`. TCP port for the unauthenticated viewer SSE broadcast server (`/stream/{room_id}`, ISSUE-30).
 - `VIEWER_BASE_URL`: Optional, defaults to `http://localhost:{SSE_PORT}`. Base URL embedded into QR codes (ISSUE-32) — set to the public viewer host (e.g. `https://captions.example.com`) in production so attendees scan a reachable URL.
 
@@ -64,10 +65,10 @@ docker run --rm -p 8501:8501 -p 8765:8765 -p 8766:8766 \
 - Line input optimization: `echoCancellation:false, noiseSuppression:false, autoGainControl:false`
 - Device switching requires stream recreation with new `deviceId`
 
-### WebRTC Connection Sequence
-1. Server: `POST /v1/realtime/sessions` → ephemeral token
+### WebRTC Connection Sequence (Realtime GA, 2026-05-12 이후)
+1. Server: `POST /v1/realtime/client_secrets` → ephemeral client secret (`ek_...`, model/세션 설정은 이 시점에 서버가 고정)
 2. Browser: SDP offer creation with audio track
-3. Browser: `POST /v1/realtime?model=...` with token + SDP → answer
+3. Browser: `POST /v1/realtime/calls` with `Authorization: Bearer ek_...` + `Content-Type: application/sdp` → answer (구 `POST /v1/realtime?model=...` 은 GA에서 400)
 4. RTCPeerConnection established, DataChannel for caption events
 
 ### Caption Event Processing

--- a/components/webrtc.html
+++ b/components/webrtc.html
@@ -636,6 +636,7 @@
     }
     .qr-code-container img {
       display: block;
+      margin: 0 auto; /* 캡션이 더 넓을 때도 QR 이 카드 중앙에 오도록 */
       width: 240px;
       height: 240px;
       max-width: 60vmin;
@@ -644,7 +645,8 @@
     .qr-code-caption {
       margin-top: 12px;
       font-size: 13px;
-      color: rgba(255, 255, 255, 0.65);
+      /* 카드가 흰 배경이므로 어두운 글자여야 보인다 */
+      color: rgba(0, 0, 0, 0.65);
       text-align: center;
       word-break: break-all;
       max-width: 360px;
@@ -652,7 +654,7 @@
       margin-right: auto;
     }
     .qr-code-caption strong {
-      color: rgba(255, 255, 255, 0.85);
+      color: rgba(0, 0, 0, 0.9);
     }
 
     /* 반응형 디자인 - 너비 기준 */
@@ -852,7 +854,7 @@
     <!-- ISSUE-32 AC4: 설정 패널에서도 QR 코드를 다시 확인할 수 있게 노출. -->
     <div class="control-group" id="settingsQrGroup" style="display: none;">
       <label>📱 뷰어 QR 코드</label>
-      <div class="qr-code-container" data-qr-container style="margin: 8px 0 0; padding: 12px;">
+      <div class="qr-code-container" data-qr-container style="margin: 8px auto 0; padding: 12px;">
         <img data-qr-img alt="자막을 볼 수 있는 뷰어 페이지로 이동하는 QR 코드"
              style="width: 160px; height: 160px;">
         <div class="qr-code-caption" style="font-size: 12px; max-width: 220px;">
@@ -928,6 +930,10 @@ try {
 
   // Global state
   let awsWebSocket = null;
+  let peerConnection = null;   // OpenAI WebRTC RTCPeerConnection
+  let dataChannel = null;      // oai-events DataChannel
+  let openaiWebSocket = null;  // 서버 번역 파이프라인 WebSocket
+  let openaiSession = null;    // BOOT 에서 로드한 세션 (client_secret 포함)
   let localStream = null;
   let currentDeviceId = null;
   let startTime = null;
@@ -2057,9 +2063,10 @@ try {
 
       console.log('📤 SDP Offer 생성됨');
 
-      // OpenAI Realtime API 에 SDP 교환 (GA: gpt-realtime, 2026-05-12 이후)
-      const realtimeModel = openaiSession.model || 'gpt-realtime';
-      const response = await fetch(`https://api.openai.com/v1/realtime?model=${encodeURIComponent(realtimeModel)}`, {
+      // OpenAI Realtime GA: SDP 교환은 /v1/realtime/calls 로 POST.
+      // 모델·세션 설정은 client_secret 발급 시 서버가 이미 고정했으므로
+      // 쿼리 파라미터가 없다 (구 /v1/realtime?model= 은 GA 에서 400).
+      const response = await fetch('https://api.openai.com/v1/realtime/calls', {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${openaiSession.client_secret}`,
@@ -2069,7 +2076,8 @@ try {
       });
 
       if (!response.ok) {
-        throw new Error(`OpenAI API 요청 실패: ${response.status}`);
+        const errBody = await response.text().catch(() => '');
+        throw new Error(`OpenAI API 요청 실패: ${response.status} ${errBody.slice(0, 300)}`);
       }
 
       const answerSdp = await response.text();
@@ -2335,8 +2343,20 @@ try {
         awsWebSocket = null;
       }
 
-      // 음성 인식 중단
-      stopSpeechRecognition();
+      // OpenAI WebRTC/WS 연결 해제 — 정지 시 토큰 만료를 기다리지 않고
+      // 즉시 끊는다 (CLAUDE.md: immediate RTCPeerConnection close)
+      if (dataChannel) {
+        dataChannel.close();
+        dataChannel = null;
+      }
+      if (peerConnection) {
+        peerConnection.close();
+        peerConnection = null;
+      }
+      if (openaiWebSocket) {
+        openaiWebSocket.close();
+        openaiWebSocket = null;
+      }
 
       // 오디오 스트림 정리
       if (localStream) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,13 @@ services:
     restart: unless-stopped
     ports:
       - "8501:8501"
-      - "8765:8765"
+      # 번역 파이프라인 WebSocket — WS_PORT 고정, 브라우저가 직접 접속 (#84)
+      - "${WS_PORT:-8765}:${WS_PORT:-8765}"
       # 뷰어 SSE 브로드캐스트 서버 (ISSUE-30) — QR 스캔한 기기가 접속하는 포트
       - "${SSE_PORT:-8766}:${SSE_PORT:-8766}"
     environment:
       - OPENAI_KEY=${OPENAI_KEY}
+      - WS_PORT=${WS_PORT:-8765}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_REGION=${AWS_REGION:-ap-northeast-2}

--- a/websocket_handler.py
+++ b/websocket_handler.py
@@ -822,59 +822,77 @@ async def _periodic_room_cleanup_loop() -> None:
             print(f"[Room] cleanup loop error: {e!r}")
 
 
+# 프로세스 단위 WS 서버 싱글턴 플래그. Streamlit 은 브라우저 세션마다
+# start_websocket_server 를 새 스레드로 부르므로, 첫 스레드만 실제 서버가
+# 되고 나머지는 포트만 보고 반환한다 (#84).
+_WS_SERVER_STARTED = False
+
+
 def start_websocket_server(port_ref):
-    """WebSocket 서버 시작 (동적 포트 할당)
+    """WebSocket 서버 시작 (WS_PORT 고정, 프로세스 단위 싱글턴)
+
+    포트는 WS_PORT 환경변수(기본 8765)로 고정한다 — Docker 포트 매핑과
+    일치해야 컨테이너 밖 브라우저가 접속할 수 있다. 이전의
+    find_free_port() 동적 할당은 세션마다 서버가 증식해 매핑 밖 포트
+    (8767, 8768, ...)로 새는 문제가 있었다 (#84).
 
     Args:
         port_ref: 포트를 저장할 dict ({"port": None})
     """
+    global _WS_SERVER_STARTED
+    ws_port = int(os.getenv("WS_PORT", "8765"))
+    port_ref["port"] = ws_port
+
+    if _WS_SERVER_STARTED:
+        print(f"[WebSocket] 서버 이미 실행 중 — 재사용: ws://0.0.0.0:{ws_port}")
+        return
+
     try:
-        free_port = find_free_port()
-        print(f"[WebSocket] 할당된 포트: {free_port}")
-        port_ref["port"] = free_port
-
-        # ISSUE-26: attach the persistent Room repository, hydrate
-        # waiting/active/inactive rooms from DB, and start the periodic
-        # stale-room cleanup. Best-effort: any failure here only
-        # downgrades to in-memory mode — server continues to start.
-        try:
-            from database import get_room_model
-
-            global _room_manager
-            repo = get_room_model()
-            _room_manager = RoomManager(room_repository=repo)
-            loaded = _room_manager.hydrate_from_db()
-            if loaded:
-                print(f"[Room] DB 복원: {loaded}개 룸")
-        except Exception as e:
-            # Fall back to in-memory mode; never block server start
-            # on persistence wiring.
-            print(f"[Room] 영속 저장소 연결 실패 — 메모리 전용 모드: {e!r}")
-
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
         async def run_server():
+            global _WS_SERVER_STARTED, _room_manager
             try:
                 server = await websockets.serve(
                     handle_openai_websocket,
                     "0.0.0.0",
-                    free_port,
+                    ws_port,
                 )
+            except OSError:
+                # 다른 세션 스레드가 먼저 바인딩함 — 그 서버를 재사용.
                 print(
-                    f"[WebSocket] 서버 시작 완료 (OpenAI 모드): "
-                    f"ws://0.0.0.0:{free_port}"
+                    f"[WebSocket] 포트 사용 중 — 기존 서버 재사용: "
+                    f"ws://0.0.0.0:{ws_port}"
                 )
-                # Background task: scan for stale rooms every minute and
-                # close them. Cancelled when wait_closed returns.
-                cleanup_task = asyncio.create_task(_periodic_room_cleanup_loop())
-                try:
-                    await server.wait_closed()
-                finally:
-                    cleanup_task.cancel()
+                return
+            _WS_SERVER_STARTED = True
+
+            # ISSUE-26: attach the persistent Room repository, hydrate
+            # waiting/active/inactive rooms from DB, and start the periodic
+            # stale-room cleanup. Best-effort: any failure here only
+            # downgrades to in-memory mode — server continues to start.
+            # 실제 서버가 된 스레드만 수행한다 — 세션마다 _room_manager 를
+            # 갈아치우면 구동 중인 서버의 룸 상태가 오염된다 (#84).
+            try:
+                from database import get_room_model
+
+                repo = get_room_model()
+                _room_manager = RoomManager(room_repository=repo)
+                loaded = _room_manager.hydrate_from_db()
+                if loaded:
+                    print(f"[Room] DB 복원: {loaded}개 룸")
             except Exception as e:
-                print(f"[WebSocket] 서버 실행 오류: {e}")
-                raise e
+                print(f"[Room] 영속 저장소 연결 실패 — 메모리 전용 모드: {e!r}")
+
+            print(f"[WebSocket] 서버 시작 완료 (OpenAI 모드): ws://0.0.0.0:{ws_port}")
+            # Background task: scan for stale rooms every minute and
+            # close them. Cancelled when wait_closed returns.
+            cleanup_task = asyncio.create_task(_periodic_room_cleanup_loop())
+            try:
+                await server.wait_closed()
+            finally:
+                cleanup_task.cancel()
 
         loop.run_until_complete(run_server())
     except Exception as e:


### PR DESCRIPTION
## 요약

로컬 Docker 리허설 Phase 2.2(실브라우저 발화 테스트)에서 발견된 블로커 묶음 수정.

Closes #84

## 변경 내용

### 1. OpenAI SDP 교환 → GA 엔드포인트 (핵심 블로커)
- `POST /v1/realtime?model=...` (preview, 2026-05-12 sunset → 400) → **`POST /v1/realtime/calls`** ([GA docs](https://developers.openai.com/api/docs/guides/realtime-webrtc))
- PR #75가 서버측(`client_secrets`)만 이전하고 브라우저측 SDP URL을 누락했던 것
- 실패 시 응답 본문 300자를 에러 메시지에 포함 (services.py와 동일한 진단 패턴)

### 2. WS 서버 포트 고정 + 프로세스 싱글턴
- 기존: `st.session_state` 가드 + `find_free_port()` → **브라우저 세션마다 서버 증식** (8765→8767→8768...), Docker 매핑(8765) 밖 포트는 접속 불가
- 변경: `WS_PORT`(기본 8765) 고정, 첫 스레드만 서버가 되고 이후는 재사용 (모듈 플래그 + EADDRINUSE 처리)
- RoomManager 하이드레이션도 실제 서버 스레드만 수행 — 세션마다 `_room_manager`를 갈아치우던 상태 오염 제거
- compose에 `WS_PORT` 매핑/전달 추가

### 3. closeConnection 정리 경로 복구
- 존재하지 않는 `stopSpeechRecognition()` (AWS Transcribe 잔재) → ReferenceError로 정리 중단되던 것 제거
- `peerConnection`/`dataChannel`/`openaiWebSocket` 즉시 해제 추가 — 정지 후에도 OpenAI 연결이 토큰 만료까지 살아있던 문제

### 4. QR 카드 스타일
- 흰 카드 위 흰 캡션 → 어두운 글자, QR 이미지 `margin: 0 auto` 중앙 정렬
- 암묵적 전역 4개(peerConnection 등) 명시 선언

## 검증
- `uv run pytest -q -m 'not e2e'` → **656 passed** (92%)
- WS 싱글턴 경로: test_websocket_handler 36개 통과
- 실브라우저 검증은 머지 후 리허설 재개로 확인 (2.2 재시도)

🤖 Generated with [Claude Code](https://claude.com/claude-code)