### PR TITLE
fix(webrtc): GA DataChannel 정합 — beta session.update 제거 + output_text 이벤트

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,8 @@ docker run --rm -p 8501:8501 -p 8765:8765 -p 8766:8766 \
 
 ### Caption Event Processing
 - Handle both delta (unstable) and completed (stable) events from DataChannel
-- Event types vary: `response.text.delta`, `conversation.item.input_audio_transcription.completed`
+- Event types (GA): `response.output_text.delta`/`.done` (browser keeps beta `response.text.*` cases as fall-through for compatibility), `conversation.item.input_audio_transcription.completed`
+- Browser MUST NOT send `session.update` — GA session config is fully pinned server-side at client_secret creation (#89)
 - UI transition: gray/italic temporary text → confirmed lines appended to scroll
 
 ### UI Behavior Requirements

--- a/components/webrtc.html
+++ b/components/webrtc.html
@@ -1784,26 +1784,10 @@ try {
 
       dataChannel.onopen = () => {
         console.log('✅ DataChannel 연결됨');
-
-        // Session instructions 전송
-        const sessionUpdate = {
-          type: 'session.update',
-          session: {
-            input_audio_format: 'pcm16',
-            input_audio_transcription: {
-              model: 'gpt-4o-transcribe',
-            },
-            turn_detection: {
-              type: 'server_vad',
-              threshold: 0.5,
-              prefix_padding_ms: 300,
-              silence_duration_ms: 500
-            }
-          }
-        };
-
-        dataChannel.send(JSON.stringify(sessionUpdate));
-        console.log('📤 Transcription-only session 설정됨');
+        // GA: 세션 설정(전사 모델·VAD·instructions·output_modalities)은
+        // 서버가 client_secret 발급 시 이미 전부 고정한다 (services.py).
+        // beta 시절의 session.update 재전송은 GA 에서 "Missing required
+        // parameter: 'session.type'" 에러만 내는 중복이라 제거 (#89).
       };
 
       dataChannel.onmessage = (event) => {
@@ -2253,7 +2237,8 @@ try {
         }
         break;
 
-      case 'response.text.delta':
+      case 'response.output_text.delta': // GA 이벤트명 (#89)
+      case 'response.text.delta':        // beta 호환
         if (message.delta && pendingTranscript) {
           const cleanDelta = message.delta.replace(/^["']|["']$/g, '');
           if (!cleanDelta.toLowerCase().includes('cannot') &&
@@ -2267,7 +2252,8 @@ try {
         }
         break;
 
-      case 'response.text.done':
+      case 'response.output_text.done': // GA 이벤트명 (#89)
+      case 'response.text.done':        // beta 호환
         if (message.text && pendingTranscript) {
           let cleanText = message.text.replace(/^["']|["']$/g, '').trim();
           console.log('[Done]', cleanText);


### PR DESCRIPTION
## 요약

Phase 2.2 재시도에서 발견된 GA DataChannel 레이어 beta 잔재 2건. #84로 SDP 교환까지는 성공했고, 이번이 그 다음 레이어.

Closes #89

## 변경 내용

### 1. beta session.update 제거
- 연결 직후 브라우저가 보내던 session.update 가 beta 형식이라 GA 가 `Missing required parameter: 'session.type'` 로 거부
- 전사 모델(gpt-4o-transcribe)·server_vad·instructions·output_modalities 는 **services.py 가 client_secret 발급 시 이미 전부 고정** — 브라우저측 재설정은 순수 중복이라 GA 형식으로 고치는 대신 제거

### 2. GA 이벤트명 대응 (silent failure 예방)
- GA 는 `response.text.delta/.done` → `response.output_text.delta/.done` 로 개명
- 핸들러에 GA case 추가, beta case 는 fall-through 로 병행 유지 (필드명 `delta`/`text` 동일)
- 미수정 시 연결은 되는데 번역 자막만 에러 없이 미표시되는 silent failure

## 검증
- Python 변경 없음 (CI 회귀 확인용)
- 실검증은 머지 후 리허설 Phase 2.2 재시도: 발화 → `[Delta]`/`[Done]` 콘솔 로그 + 자막 표시