### PR TITLE
fix(viewer): 지원 언어 전체 드롭다운 + 스크롤/정렬 복구, 룸 언어 설정 제거

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -664,23 +664,10 @@ def _render_admin_room_create(room_model, user_model, current_user):
     st.divider()
     st.subheader("➕ 새 룸 생성")
     with st.form("create_room_form"):
-        col1, col2 = st.columns(2)
-        with col1:
-            name = st.text_input("룸 이름 *", help="회의 이름 (예: A홀 기조연설)")
-            input_lang = st.selectbox(
-                "입력 언어",
-                options=["auto", "en", "ko", "ja", "zh"],
-                index=0,
-                help="auto = 자동 감지",
-            )
-        with col2:
-            output_lang = st.selectbox(
-                "출력 언어",
-                options=["ko", "en", "ja", "zh"],
-                index=0,
-            )
-            # 타임아웃 입력은 #86(auto-timeout 제거)과 함께 삭제 —
-            # 룸 종료는 아래 '강제 종료' 로 admin 이 수동 수행한다.
+        # 입력/출력 언어 설정은 #92 에서 제거 — 입력 언어는 오퍼레이터
+        # 화면에서, 자막 언어는 뷰어가 각자 드롭다운에서 선택한다
+        # (룸 설정과 무관). 타임아웃 입력은 #86 에서 제거.
+        name = st.text_input("룸 이름 *", help="회의 이름 (예: A홀 기조연설)")
 
         submitted = st.form_submit_button("룸 생성")
         if submitted:
@@ -696,8 +683,6 @@ def _render_admin_room_create(room_model, user_model, current_user):
                     room_id=room_id,
                     name=name.strip(),
                     created_by=current_user["id"],
-                    input_lang=input_lang,
-                    output_lang=output_lang,
                 )
                 st.success(f"룸 '{name}' 생성됨 (ID: {room_id})")
                 st.rerun()

--- a/admin_logic.py
+++ b/admin_logic.py
@@ -167,8 +167,6 @@ def prepare_room_table_data(
                 "이름": room.get("name", ""),
                 "상태": _format_room_status(room.get("status", "")),
                 "오퍼레이터": operator_label,
-                "입력언어": room.get("input_lang", ""),
-                "출력언어": room.get("output_lang", ""),
                 "생성자": creator_label,
                 "생성일시": room.get("created_at", ""),
                 "마지막활동": room.get("last_activity") or "-",

--- a/components/viewer.html
+++ b/components/viewer.html
@@ -147,6 +147,10 @@
       padding: 0;
     }
 
+    /* #91: 스크롤 컨테이너는 flex 를 쓰지 않는다 — flex 정렬(flex-end/
+       center)은 내용이 넘칠 때 시작 방향 오버플로를 스크롤로 도달 불가하게
+       만든다. 하단 고정 느낌은 .caption-container 의 min-height + flex-end
+       로 낸다. */
     #viewer {
       width: 100%;
       height: 100%;
@@ -155,9 +159,6 @@
       scroll-behavior: smooth;
       scrollbar-width: none;
       -ms-overflow-style: none;
-      display: flex;
-      align-items: flex-end;
-      justify-content: center;
     }
 
     #viewer::-webkit-scrollbar { display: none; }
@@ -165,10 +166,15 @@
     .caption-container {
       width: 100%;
       max-width: 1100px;
+      margin: 0 auto;
+      min-height: 100%;
       padding: 24px 20px 80px;
       display: flex;
       flex-direction: column;
+      justify-content: flex-end;
       gap: 12px;
+      /* #91: .state 의 text-align: center 상속 차단 — 자막은 좌측 정렬 */
+      text-align: left;
     }
 
     .caption-line {
@@ -302,6 +308,9 @@
       ja: "日本語",
       zh: "中文",
       vi: "Tiếng Việt",
+      es: "Español",
+      fr: "Français",
+      de: "Deutsch",
     };
 
     (function buildLangOptions() {

--- a/sse_broadcast.py
+++ b/sse_broadcast.py
@@ -36,6 +36,8 @@ from typing import Any
 
 from aiohttp import web
 
+from translation import SUPPORTED_OUTPUT_LANGS
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -318,6 +320,20 @@ def _coerce_output_langs_list(raw: Any, fallback: str) -> list[str]:
     return langs
 
 
+def _supported_output_langs(primary: str) -> list[str]:
+    """뷰어 언어 목록 — 전역 지원 언어 고정 (#91/#92).
+
+    룸별 rooms.output_langs 대신 translation.SUPPORTED_OUTPUT_LANGS 를
+    쓴다. admin 룸 설정과 무관하게 뷰어는 지원 언어 전부를 고를 수 있고,
+    번역 비용은 has_viewers lazy 게이트가 언어 단위로 제어한다.
+    primary 가 목록 밖 코드여도 앞에 끼워 넣어 드롭다운이 비지 않게 한다.
+    """
+    langs = list(SUPPORTED_OUTPUT_LANGS)
+    if primary and primary not in langs:
+        langs.insert(0, primary)
+    return langs
+
+
 def _render_viewer_html(
     *,
     room_id: str,
@@ -378,7 +394,7 @@ async def _handle_view(request: web.Request) -> web.Response:
         return web.Response(status=404, text=_NOT_FOUND_HTML, content_type="text/html")
 
     primary_lang = room.get("primary_output_lang") or "ko"
-    output_langs = _coerce_output_langs_list(room.get("output_langs"), primary_lang)
+    output_langs = _supported_output_langs(primary_lang)
     room_name = room.get("name") or room_id
     status = room.get("status") or "waiting"
     initial_state = "closed" if status == "closed" else status
@@ -597,8 +613,10 @@ async def broadcast_translation_for_room(
         },
     )
 
-    # 2) Resolve secondary languages.
-    output_langs = _coerce_output_langs(room.get("output_langs"), primary_lang)
+    # 2) Resolve secondary languages — 전역 지원 언어 기준 (#91/#92).
+    #    뷰어 없는 언어는 아래 has_viewers 게이트가 스킵하므로, 목록을
+    #    넓혀도 번역 호출 수는 늘지 않는다.
+    output_langs = _supported_output_langs(primary_lang)
     secondaries = [lang for lang in output_langs if lang != primary_lang]
     if not secondaries:
         return

--- a/tests/test_admin_room_mgmt.py
+++ b/tests/test_admin_room_mgmt.py
@@ -510,8 +510,9 @@ class TestPrepareRoomTableData:
         assert row["이름"] == "A홀"
         assert row["상태"] == "활성"
         assert row["오퍼레이터"] == "op1"
-        assert row["입력언어"] == "auto"
-        assert row["출력언어"] == "ko"
+        # #92: 입력언어/출력언어 컬럼 제거 — 언어는 룸 설정이 아님
+        assert "입력언어" not in row
+        assert "출력언어" not in row
 
     def test_unassigned_operator_displays_dash(self):
         from admin_logic import prepare_room_table_data

--- a/tests/test_sse_broadcast.py
+++ b/tests/test_sse_broadcast.py
@@ -793,6 +793,34 @@ class TestCoerceOutputLangsListWithFallback:
 
 
 # ---------------------------------------------------------------------------
+# _supported_output_langs — 전역 지원 언어 고정 (#91/#92)
+# ---------------------------------------------------------------------------
+class TestSupportedOutputLangs:
+    """뷰어 언어 목록·번역 대상이 룸 설정 대신 전역 목록을 쓴다."""
+
+    def test_returns_full_supported_list(self):
+        from sse_broadcast import _supported_output_langs
+        from translation import SUPPORTED_OUTPUT_LANGS
+
+        assert _supported_output_langs("ko") == list(SUPPORTED_OUTPUT_LANGS)
+
+    def test_unknown_primary_is_prepended(self):
+        from sse_broadcast import _supported_output_langs
+
+        result = _supported_output_langs("xx")
+        assert result[0] == "xx"
+        assert "ko" in result and "en" in result
+
+    def test_covers_langs_beyond_default_room_config(self):
+        """기본 룸 설정(ko 뿐)이던 시절과 달리 전 언어가 선택 가능해야 한다."""
+        from sse_broadcast import _supported_output_langs
+
+        result = _supported_output_langs("ko")
+        for lang in ("en", "ja", "zh", "vi"):
+            assert lang in result
+
+
+# ---------------------------------------------------------------------------
 # /view/{room_id} (lines 367-399, 394-397)
 # ---------------------------------------------------------------------------
 class TestHandleView:

--- a/translation.py
+++ b/translation.py
@@ -18,6 +18,20 @@ SOURCE_LANG_NAMES = {
     "de": "독일어",
 }
 
+# 뷰어가 선택할 수 있는 자막 언어 전체 (#91/#92).
+# 룸별 output_langs 설정 대신 전역 고정 목록을 쓴다 — SSE lazy 게이트
+# (has_viewers)가 언어별 번역 비용을 이미 제어하므로 룸 제한이 불필요.
+SUPPORTED_OUTPUT_LANGS: tuple[str, ...] = (
+    "ko",
+    "en",
+    "ja",
+    "zh",
+    "vi",
+    "es",
+    "fr",
+    "de",
+)
+
 # Bedrock 모델 ID (품질 → 속도 순, 앞이 실패하면 뒤로 폴백)
 #
 # 이전 목록(claude-3-5-sonnet-20240620, claude-3-haiku-20240307,

--- a/websocket_handler.py
+++ b/websocket_handler.py
@@ -573,14 +573,12 @@ async def _publish_to_viewers(
         return
 
     # _handle_transcript 가 이미 정한 target_lang 으로 메인 채널을 매핑한다.
-    # rooms.primary_output_lang 은 룸 운영자가 정한 행사장 메인 언어이며,
-    # 일반적으로 target_lang 과 일치한다 (오퍼레이터의 output_lang 설정과 함께
-    # 운영). 만약 양쪽이 다르면 운영자 설정을 우선해 source-of-truth 로 삼는다 —
-    # 행사장 화면에 실제로 송출되는 텍스트가 메인 채널이어야 하기 때문.
+    # 오퍼레이터 설정이 source-of-truth — 행사장 화면에 실제로 송출되는
+    # 텍스트가 메인 채널이어야 하기 때문. 추가 언어 목록은 룸 설정이 아니라
+    # 전역 지원 언어(#91/#92)를 broadcast 쪽이 직접 쓴다.
     room_for_publish = {
         "id": room_id,
         "primary_output_lang": target_lang,
-        "output_langs": room_row.get("output_langs"),
     }
 
     async def _translate_fn(text, src, dst):


### PR DESCRIPTION
## 요약

로컬 리허설에서 발견된 뷰어 3건(#91)과 룸 언어 설정 정리(#92). 같은 뿌리(언어 소스가 room.output_langs)라 한 PR로 처리.

Closes #91
Closes #92

## #91 — 뷰어 수정

| 증상 | 원인 | 수정 |
|---|---|---|
| 드롭다운에 한국어만 | `rooms.output_langs` 기본 `["ko"]`를 admin 폼이 안 채움 | 전역 `SUPPORTED_OUTPUT_LANGS`(8개 언어)로 전환 — 드롭다운·서버 번역 대상 동일 소스 |
| 자막 가운데 정렬 | `.state`의 `text-align: center` 상속 | `.caption-container`에서 left로 차단 |
| 스크롤 불가 | `#viewer`의 flex `align-items: flex-end` — 오버플로가 스크롤 도달 불가 영역으로 감 | 컨테이너 min-height + `justify-content: flex-end` 패턴 (하단 고정 유지, 스크롤 정상) |

번역 비용: `has_viewers` lazy 게이트가 언어 단위로 스킵하므로 목록을 넓혀도 Bedrock 호출 수 불변.

## #92 — 룸 언어 설정 제거

- admin이 정한 입력/출력 언어가 오퍼레이터 화면과 동기화되지 않던 죽은 설정 → 폼에서 제거, 룸은 이름만 받음
- 입력 언어는 오퍼레이터 화면에서, 자막 언어는 뷰어가 각자 선택
- 룸 테이블의 언어 컬럼 제거, DB 컬럼은 호환성 위해 유지

## 검증

- `uv run pytest -q -m 'not e2e'` → **658 passed**, 커버리지 92.97%
- 신규 테스트 3개(`_supported_output_langs`), 기존 lazy 게이트·뷰어 페이지 테스트는 새 계약과 그대로 호환 (수정 1건 — 제거된 테이블 컬럼 단언만 갱신)
- 실검증: 머지 후 뷰어에서 8개 언어 드롭다운 + 좌측 정렬 + 스크롤 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)