### PR TITLE
fix(admin): 사용자 생성/수정 폼에서 operator 역할 선택 가능

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -14,6 +14,8 @@ import streamlit as st
 from admin_logic import (
     DEFAULT_ROOM_LIST_STATUSES,
     ROOM_STATUS_FILTER_OPTIONS,
+    SELECTABLE_USER_ROLES,
+    UNLIMITED_USAGE_ROLES,
     build_room_metrics_view_data,
     export_room_logs_csv,
     filter_rooms_by_status,
@@ -21,6 +23,7 @@ from admin_logic import (
     format_room_status,
     get_logs_for_operator,
     prepare_room_table_data,
+    role_select_index,
     validate_room_creation_input,
 )
 from auth import (
@@ -195,8 +198,8 @@ def show_user_management(user_model):
                     )
                     new_role = st.selectbox(
                         "역할",
-                        options=["user", "admin"],
-                        index=0 if selected_user["role"] == "user" else 1,
+                        options=list(SELECTABLE_USER_ROLES),
+                        index=role_select_index(selected_user["role"]),
                     )
 
                 with col2:
@@ -299,7 +302,7 @@ def show_create_user_form(user_model):
         with col2:
             email = st.text_input("이메일")
             full_name = st.text_input("소속")
-            role = st.selectbox("역할", options=["user", "admin"], index=0)
+            role = st.selectbox("역할", options=list(SELECTABLE_USER_ROLES), index=0)
 
         usage_limit_hours = st.number_input(
             "사용 가능 시간 (시간)",
@@ -325,9 +328,10 @@ def show_create_user_form(user_model):
                 st.error("비밀번호는 최소 6자 이상이어야 합니다.")
                 return
 
-            # 사용량 제한 계산 (관리자는 무제한)
+            # 사용량 제한 계산 — 세션을 직접 운영하는 권한 역할(admin,
+            # operator)은 무제한 (#95: 컨퍼런스 장시간 세션 중 끊김 방지).
             usage_limit_seconds = (
-                0 if role == "admin" else int(usage_limit_hours * 3600)
+                0 if role in UNLIMITED_USAGE_ROLES else int(usage_limit_hours * 3600)
             )
 
             # 사용자 생성

--- a/admin_logic.py
+++ b/admin_logic.py
@@ -24,6 +24,24 @@ def _format_room_status(status: str) -> str:
     return _ROOM_STATUS_KOR_LABELS.get(status, status)
 
 
+# admin 사용자 생성/수정 폼의 역할 selectbox 옵션 (#95).
+# operator 는 auth.is_operator / 룸 배정에서 쓰이는 정식 역할이므로 UI 에서
+# 반드시 선택 가능해야 한다. 순서 = selectbox 표시 순서.
+SELECTABLE_USER_ROLES: tuple[str, ...] = ("user", "operator", "admin")
+
+# 생성 시 사용량 무제한으로 두는 역할 — 세션을 직접 운영하는 권한 역할.
+# operator 는 컨퍼런스 장시간 세션을 돌리므로 중간에 한도로 끊기면 안 된다.
+UNLIMITED_USAGE_ROLES: frozenset[str] = frozenset({"admin", "operator"})
+
+
+def role_select_index(role: str) -> int:
+    """수정 폼 selectbox 의 초기 index — 미지 역할은 0(user)로 방어."""
+    try:
+        return SELECTABLE_USER_ROLES.index(role)
+    except ValueError:
+        return 0
+
+
 def validate_password(password: str, confirm: str) -> tuple[bool, str]:
     """비밀번호 유효성 검증
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -8,7 +8,37 @@ import io
 
 import pytest
 
-from admin_logic import export_user_logs_csv, prepare_user_table_data, validate_password
+from admin_logic import (
+    SELECTABLE_USER_ROLES,
+    UNLIMITED_USAGE_ROLES,
+    export_user_logs_csv,
+    prepare_user_table_data,
+    role_select_index,
+    validate_password,
+)
+
+
+# ============================================================
+# 역할 선택 (#95) — operator 를 UI 에서 생성/수정 가능해야 한다
+# ============================================================
+class TestUserRoleSelection:
+    def test_operator_is_selectable(self):
+        assert "operator" in SELECTABLE_USER_ROLES
+        # user/admin 도 그대로 유지
+        assert set(SELECTABLE_USER_ROLES) == {"user", "operator", "admin"}
+
+    def test_role_select_index_maps_each_role(self):
+        for role in SELECTABLE_USER_ROLES:
+            assert SELECTABLE_USER_ROLES[role_select_index(role)] == role
+
+    def test_role_select_index_unknown_defaults_to_user(self):
+        idx = role_select_index("nonexistent")
+        assert SELECTABLE_USER_ROLES[idx] == "user"
+
+    def test_operator_and_admin_are_unlimited(self):
+        assert "operator" in UNLIMITED_USAGE_ROLES
+        assert "admin" in UNLIMITED_USAGE_ROLES
+        assert "user" not in UNLIMITED_USAGE_ROLES
 
 
 # ============================================================


### PR DESCRIPTION
## 요약

admin UI에서 operator 역할을 만들 수 없어 CLI 우회로만 생성 가능하던 버그. 로컬 리허설에서 발견.

Closes #95

## 변경 내용

- **생성/수정 폼 selectbox**: `["user", "admin"]` → `["user", "operator", "admin"]`
- **수정 폼 index 버그**: `0 if role=="user" else 1` 이라 기존 operator를 열면 "admin"으로 잘못 표시되던 것 → `role_select_index()` 값 기반 매핑 (미지 값은 user로 방어)
- **usage_limit**: operator도 admin처럼 무제한 (`UNLIMITED_USAGE_ROLES`) — 컨퍼런스 장시간 세션 중 한도로 끊기지 않도록. ⚠️ 이 부분은 제품 결정이라 리뷰 포인트: operator에게 시간 제한을 두고 싶으면 알려주세요
- 공유 상수/헬퍼(`SELECTABLE_USER_ROLES`, `role_select_index`, `UNLIMITED_USAGE_ROLES`)를 `admin_logic`에 두고 두 폼에서 재사용

## 검증
- `uv run pytest -q -m 'not e2e'` → **662 passed**, 커버리지 93%
- 신규 테스트 4개 (operator 선택 가능/index 매핑/미지 값 방어/무제한 역할)

🤖 Generated with [Claude Code](https://claude.com/claude-code)