### PR TITLE
fix(operator): admin 은 자막 세션 시작 불가 — 관리 전용 역할

### DIFF
--- a/app.py
+++ b/app.py
@@ -117,6 +117,9 @@ with st.sidebar:
     assigned_rooms = _load_assigned_rooms_for_user(sidebar_user)
     selected_room_id = None
     show_room_section = sidebar_user is not None and sidebar_user.get("role") != "admin"
+    # admin 은 룸 배정 개념이 없어 자막 세션을 시작할 수 없다 — 관리 전용
+    # 역할이다 (#101). 실제 세션은 룸이 배정된 operator 만 운영한다.
+    is_admin_role = sidebar_user is not None and sidebar_user.get("role") == "admin"
 
     if show_room_section:
         st.markdown("---")
@@ -168,6 +171,7 @@ with st.sidebar:
                 "starting",
             ]
             or no_room_for_operator
+            or is_admin_role
         )
         start = st.button(
             "🎯 시작",
@@ -175,7 +179,14 @@ with st.sidebar:
             use_container_width=True,
             disabled=start_disabled,
             help=(
-                "배정된 룸이 없어 시작할 수 없습니다." if no_room_for_operator else None
+                "관리자 계정은 자막 세션을 시작할 수 없습니다. "
+                "룸/사용자 관리는 관리자 대시보드를 이용하세요."
+                if is_admin_role
+                else (
+                    "배정된 룸이 없어 시작할 수 없습니다."
+                    if no_room_for_operator
+                    else None
+                )
             ),
         )
 
@@ -275,7 +286,9 @@ if "action" not in st.session_state:
 
 # === Handle actions ===
 openai_session = None
-if start:
+# admin 은 세션 시작 불가 (#101). 버튼이 disabled 라 여기 도달할 일은
+# 없지만, 서버측 방어로 한 번 더 막는다.
+if start and not is_admin_role:
     try:
         st.session_state["sidebar_state"] = "expanded"
 
@@ -342,31 +355,40 @@ def _build_view_url_and_qr(room_id: str | None) -> tuple[str | None, str | None]
 
 
 # === 메인 캡션 뷰어 ===
-try:
-    with open("components/webrtc.html", encoding="utf-8") as f:
-        html_template = f.read()
-
-    current_user = get_current_user()
-
-    # ISSUE-32: 오퍼레이터 룸이 선택된 경우에만 QR 데이터 동봉.
-    bootstrap_room_id = st.session_state.get("selected_room_id")
-    view_url, qr_data_url = _build_view_url_and_qr(bootstrap_room_id)
-
-    payload = build_bootstrap_payload(
-        action=st.session_state["action"],
-        openai_session=st.session_state.get("openai_session"),
-        websocket_port=st.session_state["websocket_port_ref"]["port"],
-        user_info=current_user,
-        room_id=bootstrap_room_id,
-        # ISSUE-28 AC3: 웰컴 화면에 룸 이름을 보이기 위한 BOOT 필드.
-        room_name=st.session_state.get("selected_room_name"),
-        # ISSUE-32: 웰컴 화면에 QR 코드를 표시하기 위한 BOOT 필드.
-        view_url=view_url,
-        qr_data_url=qr_data_url,
+# admin 은 관리 전용 (#101) — 캡션/마이크 컴포넌트 대신 안내만 표시한다.
+# admin 은 룸 배정이 없어 세션을 시작할 수 없고, default 룸으로 붙으면
+# 번역이 실패하므로 (컴포넌트를 아예 렌더하지 않는다).
+if (get_current_user() or {}).get("role") == "admin":
+    st.info(
+        "👋 관리자 계정입니다. 자막 세션은 룸이 배정된 오퍼레이터 계정에서 "
+        "운영합니다. 사이드바의 **관리자 대시보드**에서 룸과 사용자를 관리하세요."
     )
+else:
+    try:
+        with open("components/webrtc.html", encoding="utf-8") as f:
+            html_template = f.read()
 
-    html_content = html_template.replace("{{BOOTSTRAP_JSON}}", json.dumps(payload))
-    st.components.v1.html(html_content, height=900, scrolling=False)
+        current_user = get_current_user()
 
-except Exception:
-    st.error("❌ 시스템을 로드할 수 없습니다.")
+        # ISSUE-32: 오퍼레이터 룸이 선택된 경우에만 QR 데이터 동봉.
+        bootstrap_room_id = st.session_state.get("selected_room_id")
+        view_url, qr_data_url = _build_view_url_and_qr(bootstrap_room_id)
+
+        payload = build_bootstrap_payload(
+            action=st.session_state["action"],
+            openai_session=st.session_state.get("openai_session"),
+            websocket_port=st.session_state["websocket_port_ref"]["port"],
+            user_info=current_user,
+            room_id=bootstrap_room_id,
+            # ISSUE-28 AC3: 웰컴 화면에 룸 이름을 보이기 위한 BOOT 필드.
+            room_name=st.session_state.get("selected_room_name"),
+            # ISSUE-32: 웰컴 화면에 QR 코드를 표시하기 위한 BOOT 필드.
+            view_url=view_url,
+            qr_data_url=qr_data_url,
+        )
+
+        html_content = html_template.replace("{{BOOTSTRAP_JSON}}", json.dumps(payload))
+        st.components.v1.html(html_content, height=900, scrolling=False)
+
+    except Exception:
+        st.error("❌ 시스템을 로드할 수 없습니다.")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -15,6 +15,9 @@ import pytest
 # 테스트 계정 정보
 TEST_USERNAME = "e2e_admin"
 TEST_PASSWORD = "e2e_test_pass_123"
+# 캡션 UI 는 operator 역할에서만 렌더된다 (admin 은 관리 전용, #101).
+# logged_in_page 는 이 operator 로 로그인해 캡션 컴포넌트를 띄운다.
+TEST_OPERATOR_USERNAME = "e2e_operator"
 
 # Streamlit 서버 포트
 STREAMLIT_PORT = 8599
@@ -81,6 +84,25 @@ def streamlit_server(_tmp_db_dir):
             f"Streamlit server failed to start\nstdout: {stdout}\nstderr: {stderr}"
         )
 
+    # 캡션 UI E2E 는 operator 계정으로 수행한다 (#101: admin 은 관리 전용이라
+    # 캡션 컴포넌트를 렌더하지 않음). 서버와 동일한 DB 파일에 operator 를
+    # 직접 생성한다 — DatabaseManager.__init__ 은 멱등(IF NOT EXISTS)이다.
+    try:
+        from database import DatabaseManager, User
+
+        dbm = DatabaseManager(db_path)
+        user_repo = User(dbm)
+        if user_repo.get_user_by_username(TEST_OPERATOR_USERNAME) is None:
+            user_repo.create_user(
+                username=TEST_OPERATOR_USERNAME,
+                password=TEST_PASSWORD,
+                role="operator",
+                usage_limit_seconds=36000,
+            )
+    except Exception as e:
+        proc.terminate()
+        pytest.fail(f"E2E operator 계정 생성 실패: {e!r}")
+
     yield base_url
 
     proc.terminate()
@@ -109,7 +131,8 @@ def logged_in_page(page, streamlit_server):
         login_needed = username_input.count() > 0
 
     if login_needed:
-        username_input.fill(TEST_USERNAME)
+        # operator 로 로그인 — 캡션 컴포넌트가 렌더되어야 하기 때문 (#101).
+        username_input.fill(TEST_OPERATOR_USERNAME)
         password_input = page.locator('input[aria-label="비밀번호"]')
         password_input.wait_for(state="visible", timeout=5000)
         password_input.fill(TEST_PASSWORD)


### PR DESCRIPTION
## 요약

admin 이 발화하면 번역이 "로그인이 필요합니다"로 실패하던 문제. admin 은 룸 배정이 없어 세션 시작 시 room_id='default'(DB 미존재)로 붙어 WS 인증이 거부됨. **Option A** — admin 을 관리 전용으로 확정하고 세션 시작 경로를 차단.

Closes #101

## 변경 내용
- **시작 버튼**: admin 이면 disabled + "관리자 계정은 자막 세션을 시작할 수 없습니다" help
- **시작 핸들러**: `if start and not is_admin_role` 서버측 방어 가드
- **메인 영역**: admin 이면 캡션/마이크 컴포넌트를 렌더하지 않고 "관리자 대시보드로" 안내 표시
- operator(룸 배정) 플로우는 변경 없음

## 참고
- admin 이 직접 테스트하려면 operator 계정 사용 (#96 으로 UI 에서 생성 가능)
- 'default' 룸 자동생성 폴백이 dead path 인 것도 이 과정에서 확인 (브라우저가 항상 'default' 문자열 전송) — admin 차단으로 실사용 경로에선 무의미해짐

## 검증
- `uv run pytest -q -m 'not e2e'` → **662 passed**, 커버리지 93%

🤖 Generated with [Claude Code](https://claude.com/claude-code)