### PR TITLE
fix(translation): 뷰어 지원 언어 ko/zh/vi/ja 확정 + ja 번역 복구

### DIFF
--- a/tests/test_multilang_translation.py
+++ b/tests/test_multilang_translation.py
@@ -12,6 +12,7 @@ from translation import (
     SOURCE_LANG_NAMES,
     _build_prompt_to_chinese,
     _build_prompt_to_english,
+    _build_prompt_to_japanese,
     _build_prompt_to_vietnamese,
     translate_with_llm,
 )
@@ -106,6 +107,29 @@ class TestBuildPromptToVietnamese:
         assert "Huong dan dich" in prompt
 
 
+# === _build_prompt_to_japanese 테스트 (#103) ===
+
+
+class TestBuildPromptToJapanese:
+    def test_contains_source_text(self):
+        prompt = _build_prompt_to_japanese("Hello world", "en")
+        assert "Hello world" in prompt
+
+    def test_contains_japanese_instructions(self):
+        """일본어 번역 프롬프트여야 한다 (영어 기본값으로 새지 않음)."""
+        prompt = _build_prompt_to_japanese("Hello", "en")
+        assert "日本語" in prompt
+        assert "日本語訳" in prompt
+
+    def test_english_source_shows_label(self):
+        prompt = _build_prompt_to_japanese("Hello", "en")
+        assert SOURCE_LANG_NAMES["en"] in prompt
+
+    def test_unknown_source_uses_fallback(self):
+        prompt = _build_prompt_to_japanese("Hello", "xx")
+        assert "元の言語" in prompt
+
+
 # === _build_prompt_to_english 확장 테스트 ===
 
 
@@ -182,6 +206,17 @@ class TestTranslateWithLlmMultilang:
         result = translate_with_llm(mock_client, "안녕하세요", "ko", "vi")
         assert result is not None
         assert "Xin chao" in result
+
+    def test_translate_en_to_ja_uses_japanese_prompt(self):
+        """#103 회귀: ja 는 일본어 프롬프트로 가야 한다 (영어 기본값 금지)."""
+        mock_client = self._make_mock_bedrock("こんにちは")
+        result = translate_with_llm(mock_client, "Hello", "en", "ja")
+        assert result is not None and "こんにちは" in result
+        # 실제 Bedrock 에 보낸 body(JSON)를 파싱해 프롬프트가 일본어인지 검증.
+        sent_body = mock_client.invoke_model.call_args.kwargs["body"]
+        prompt = json.loads(sent_body)["messages"][0]["content"][0]["text"]
+        assert "日本語訳" in prompt
+        assert "국제 컨퍼런스" not in prompt  # 영어 프롬프트 마커가 아님
 
     def test_translate_zh_to_en(self):
         """중국어 -> 영어 번역"""

--- a/tests/test_sse_broadcast.py
+++ b/tests/test_sse_broadcast.py
@@ -425,24 +425,24 @@ class TestLazyTranslationAndNonBlocking:
         )
 
         mgr = BroadcastManager()
-        # 메인 언어 ko, 추가 언어 en.
+        # 메인 언어 ko, 추가 언어 ja (#103: secondary 는 SUPPORTED_OUTPUT_LANGS
+        # 기준이므로 ko/ja/zh/vi 중에서 고른다).
         room = {
             "id": "r1",
             "primary_output_lang": "ko",
-            "output_langs": ["ko", "en"],
         }
         # 메인 + 추가 언어 모두 viewer 등록
         ko_q = await mgr.register_viewer("r1", "ko")
-        en_q = await mgr.register_viewer("r1", "en")
+        ja_q = await mgr.register_viewer("r1", "ja")
 
         slow_calls: list[str] = []
 
         async def fake_translate(text: str, src: str, dst: str) -> str:
-            if dst == "en":
-                slow_calls.append("en-start")
+            if dst == "ja":
+                slow_calls.append("ja-start")
                 await asyncio.sleep(0.5)  # secondary lang is artificially slow
-                slow_calls.append("en-done")
-                return "Hello"
+                slow_calls.append("ja-done")
+                return "こんにちは"
             return "안녕"  # primary path is fast
 
         translated_main = "안녕"
@@ -470,10 +470,10 @@ class TestLazyTranslationAndNonBlocking:
         assert "timestamp" in msg_main
 
         # Then the secondary message arrives later.
-        msg_secondary = await asyncio.wait_for(en_q.get(), timeout=2.0)
-        assert msg_secondary["text"] == "Hello"
-        assert msg_secondary["lang"] == "en"
-        assert "en-done" in slow_calls
+        msg_secondary = await asyncio.wait_for(ja_q.get(), timeout=2.0)
+        assert msg_secondary["text"] == "こんにちは"
+        assert msg_secondary["lang"] == "ja"
+        assert "ja-done" in slow_calls
 
     @pytest.mark.asyncio
     async def test_secondary_translation_skipped_when_no_viewers(self):
@@ -528,14 +528,14 @@ class TestLazyTranslationAndNonBlocking:
         )
 
         mgr = BroadcastManager()
+        # #103: secondary 는 SUPPORTED_OUTPUT_LANGS(ko/ja/zh/vi) 기준.
         room = {
             "id": "r1",
             "primary_output_lang": "ko",
-            "output_langs": ["ko", "en", "ja", "zh"],
         }
         await mgr.register_viewer("r1", "ko")
-        en_q = await mgr.register_viewer("r1", "en")
-        # ja, zh 는 viewer 없음 — 번역 스킵 대상
+        ja_q = await mgr.register_viewer("r1", "ja")
+        # zh, vi 는 viewer 없음 — 번역 스킵 대상
 
         secondary_calls: list[str] = []
 
@@ -552,10 +552,10 @@ class TestLazyTranslationAndNonBlocking:
             translate_fn=fake_translate,
         )
 
-        msg = await asyncio.wait_for(en_q.get(), timeout=2.0)
-        assert msg["text"] == "[en]hi"
-        # ja, zh 는 호출되지 않음
-        assert secondary_calls == ["en"], secondary_calls
+        msg = await asyncio.wait_for(ja_q.get(), timeout=2.0)
+        assert msg["text"] == "[ja]hi"
+        # zh, vi 는 호출되지 않음
+        assert secondary_calls == ["ja"], secondary_calls
 
 
 # ---------------------------------------------------------------------------
@@ -809,14 +809,15 @@ class TestSupportedOutputLangs:
 
         result = _supported_output_langs("xx")
         assert result[0] == "xx"
-        assert "ko" in result and "en" in result
+        assert "ko" in result and "ja" in result
 
     def test_covers_langs_beyond_default_room_config(self):
-        """기본 룸 설정(ko 뿐)이던 시절과 달리 전 언어가 선택 가능해야 한다."""
+        """기본 룸 설정(ko 뿐)이던 시절과 달리 지원 언어 전부 선택 가능."""
         from sse_broadcast import _supported_output_langs
 
         result = _supported_output_langs("ko")
-        for lang in ("en", "ja", "zh", "vi"):
+        # #103: 지원 언어는 ko/ja/zh/vi (전용 번역 프롬프트가 있는 것만).
+        for lang in ("ko", "ja", "zh", "vi"):
             assert lang in result
 
 

--- a/translation.py
+++ b/translation.py
@@ -18,18 +18,17 @@ SOURCE_LANG_NAMES = {
     "de": "독일어",
 }
 
-# 뷰어가 선택할 수 있는 자막 언어 전체 (#91/#92).
+# 뷰어가 선택할 수 있는 자막 언어 (#91/#92, #103).
 # 룸별 output_langs 설정 대신 전역 고정 목록을 쓴다 — SSE lazy 게이트
 # (has_viewers)가 언어별 번역 비용을 이미 제어하므로 룸 제한이 불필요.
+# translate_with_llm 이 전용 프롬프트를 가진 언어만 포함한다 — 프롬프트가
+# 없으면 영어 기본값으로 잘못 번역되므로(#103), 목록과 프롬프트 커버리지를
+# 반드시 일치시킬 것.
 SUPPORTED_OUTPUT_LANGS: tuple[str, ...] = (
     "ko",
-    "en",
     "ja",
     "zh",
     "vi",
-    "es",
-    "fr",
-    "de",
 )
 
 # Bedrock 모델 ID (품질 → 속도 순, 앞이 실패하면 뒤로 폴백)
@@ -215,6 +214,27 @@ def _build_prompt_to_chinese(text, source_lang):
 中文翻译:"""
 
 
+def _build_prompt_to_japanese(text, source_lang):
+    """일본어 번역 프롬프트 생성"""
+    source_lang_name = SOURCE_LANG_NAMES.get(source_lang, "元の言語")
+    return f"""次の{source_lang_name}のテキストを自然な日本語に翻訳してください。
+リアルタイム会議・技術発表の字幕であり、直訳よりも意味の伝達を優先します。
+
+原文: "{text}"
+
+翻訳ガイドライン:
+- 意味重視: 原文の核心的な意味を自然に伝える
+- 聞き手に優しい: 聴衆が理解しやすい日本語表現
+- 文脈適合: 技術発表・ビジネスの場にふさわしいトーン
+- 簡潔: リアルタイム字幕に適した簡潔な文（最大2文）
+- 用語処理: 技術用語は日本の開発者が実際に使う表現
+- 自然な表現: 日本語の語順と慣用表現を優先し、直訳を避ける
+
+翻訳結果のみを出力してください（説明・注釈・補足は一切禁止）:
+
+日本語訳:"""
+
+
 def _build_prompt_to_vietnamese(text, source_lang):
     """베트남어 번역 프롬프트 생성"""
     source_lang_name = SOURCE_LANG_NAMES.get(source_lang, "ngon ngu goc")
@@ -295,11 +315,15 @@ def translate_with_llm(bedrock_client, text, source_lang, target_lang):
     try:
         if target_lang == "ko":
             prompt = _build_prompt_to_korean(text, source_lang)
+        elif target_lang == "ja":
+            prompt = _build_prompt_to_japanese(text, source_lang)
         elif target_lang == "zh":
             prompt = _build_prompt_to_chinese(text, source_lang)
         elif target_lang == "vi":
             prompt = _build_prompt_to_vietnamese(text, source_lang)
         else:
+            # en 등 나머지 (오퍼레이터 output_lang=en 경로). 뷰어 지원 언어
+            # (SUPPORTED_OUTPUT_LANGS)는 위 4개로 한정되므로 여기엔 안 온다.
             prompt = _build_prompt_to_english(text, source_lang)
 
         body = json.dumps(


### PR DESCRIPTION
## 요약

뷰어가 일본어 선택 시 **영어로 번역**되고, es/fr/de는 **동작 안 하던** 문제. 지원 언어를 ko/zh/vi/ja로 확정.

Closes #103

## 원인
`translate_with_llm`이 ko/zh/vi만 명시 처리하고 나머지는 `else → _build_prompt_to_english` → ja/es/fr/de가 전부 영어 프롬프트로 감. #91이 뷰어 언어를 8개로 넓혔으나 번역 프롬프트는 4개(ko/zh/vi/en)만 커버 → 불일치.

## 변경
- `SUPPORTED_OUTPUT_LANGS` → **(ko, ja, zh, vi)** (전용 프롬프트 있는 것만). 뷰어 드롭다운·서버 secondary 번역 대상 자동 일치.
- `_build_prompt_to_japanese` 추가 + `translate_with_llm`에 `ja` 분기 연결 → 일본어로 정상 번역.
- en/es/fr/de는 뷰어 목록에서 제외 (en은 오퍼레이터 output_lang 경로에서만 내부적으로 사용).

## 검증
- `uv run pytest -q -m 'not e2e'` → **671 passed**, 커버리지 93%
- 신규: ja 프롬프트 빌더 테스트 4개 + ja 분기 회귀 테스트(실제 body가 일본어 프롬프트인지 검증)
- 기존 lazy-translation 테스트를 새 계약(secondary=SUPPORTED)에 맞게 en→ja 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)