### PR TITLE
design(ui): operator/viewer 미니멀 다크 리디자인

### DIFF
--- a/components/viewer.html
+++ b/components/viewer.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>{{ROOM_NAME}} — 자막 뷰어</title>
   <style>
-    /* RL-011: 100vh + 100dvh fallback for iOS Safari (declared in this order
-       so dvh wins via cascade on supporting browsers, vh remains the fallback
-       for older Safari < 15.4). */
+    /* Minimal-dark viewer (design #109): near-black canvas, monochrome type,
+       no cards/borders — captions read like a keynote teleprompter.
+       RL-011: 100vh + 100dvh fallback for iOS Safari (order matters). */
     *, *::before, *::after { box-sizing: border-box; }
 
     html, body {
@@ -20,84 +20,103 @@
     }
 
     body {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-        "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
-      background: linear-gradient(135deg, #0f0f23 0%, #1a1a2e 50%, #16213e 100%);
+      font-family: "Pretendard", -apple-system, BlinkMacSystemFont, "Segoe UI",
+        Roboto, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+      background: #0b0b0c;
       color: #ffffff;
       -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
       word-break: keep-all;
       line-height: 1.6;
     }
 
-    /* App shell — full viewport flex column */
     .app {
       display: flex;
       flex-direction: column;
       height: 100vh;
       height: 100dvh;
       width: 100%;
-      max-width: 100%;
     }
 
-    /* Header — language selector + room name */
+    /* Header — room name + live dot (left), language selector (right) */
     .topbar {
       flex: 0 0 auto;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 12px;
-      padding: 14px 20px;
-      background: rgba(15, 15, 35, 0.7);
-      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-      backdrop-filter: blur(8px);
+      gap: 16px;
+      padding: 18px 28px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    .room-meta {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      min-width: 0;
+    }
+
+    /* Single subtle status dot — the only color in the UI */
+    .live-dot {
+      flex: 0 0 auto;
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.22);
+      transition: background 0.4s ease, box-shadow 0.4s ease;
+    }
+    .live-dot.live {
+      background: #4ade80;
+      box-shadow: 0 0 0 4px rgba(74, 222, 128, 0.12);
+      animation: live-pulse 2.4s ease-in-out infinite;
+    }
+    @keyframes live-pulse {
+      0%, 100% { box-shadow: 0 0 0 4px rgba(74, 222, 128, 0.10); }
+      50%      { box-shadow: 0 0 0 6px rgba(74, 222, 128, 0.04); }
     }
 
     .room-name {
-      font-size: 14px;
+      font-size: 13px;
       font-weight: 500;
-      color: rgba(255, 255, 255, 0.7);
-      letter-spacing: 0.02em;
-      max-width: 60%;
+      letter-spacing: 0.06em;
+      color: rgba(255, 255, 255, 0.42);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
     }
 
-    .lang-control {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-
+    .lang-control { display: flex; align-items: center; gap: 10px; }
     .lang-control label {
-      font-size: 13px;
-      color: rgba(255, 255, 255, 0.6);
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: rgba(255, 255, 255, 0.35);
     }
 
     #lang-select {
-      min-height: 44px; /* WCAG 2.1 touch target — RL-010 */
+      min-height: 40px; /* WCAG touch target (RL-010) */
       padding: 8px 14px;
-      border: 1px solid rgba(255, 255, 255, 0.2);
-      border-radius: 10px;
-      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      border-radius: 8px;
+      background: transparent;
       color: #ffffff;
-      font-size: 15px;
+      font-size: 14px;
+      font-family: inherit;
       cursor: pointer;
+      transition: border-color 0.2s ease;
+      -webkit-appearance: none;
+      appearance: none;
     }
-
+    #lang-select:hover { border-color: rgba(255, 255, 255, 0.3); }
     #lang-select:focus-visible {
-      outline: 2px solid #10b981;
-      outline-offset: 2px;
+      outline: none;
+      border-color: rgba(255, 255, 255, 0.6);
     }
+    #lang-select option { background: #151517; color: #ffffff; }
 
-    /* Main content — viewer scrolls inside */
-    .main {
-      flex: 1 1 auto;
-      position: relative;
-      overflow: hidden;
-    }
+    .main { flex: 1 1 auto; position: relative; overflow: hidden; }
 
-    /* Three states share the same area; hidden by default until JS toggles. */
+    /* Three states share the same area; hidden until JS toggles .active */
     .state {
       position: absolute;
       inset: 0;
@@ -105,52 +124,43 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      padding: 24px 20px;
+      padding: 24px 24px;
       text-align: center;
     }
+    .state.active { display: flex; }
 
-    .state.active {
-      display: flex;
-    }
-
-    /* Waiting state */
+    /* Waiting / ended states */
     .state-message {
-      font-size: clamp(20px, 4vw, 32px);
+      font-size: clamp(22px, 3.4vw, 34px);
       font-weight: 300;
-      color: rgba(255, 255, 255, 0.85);
+      color: rgba(255, 255, 255, 0.8);
       max-width: 720px;
       letter-spacing: -0.01em;
     }
-
     .state-room {
-      margin-top: 18px;
-      font-size: clamp(14px, 2vw, 18px);
-      color: rgba(255, 255, 255, 0.45);
+      margin-top: 20px;
+      font-size: 13px;
+      letter-spacing: 0.04em;
+      color: rgba(255, 255, 255, 0.35);
     }
-
     .state-spinner {
-      width: 36px;
-      height: 36px;
-      margin-top: 24px;
-      border: 3px solid rgba(255, 255, 255, 0.15);
-      border-top-color: #10b981;
+      width: 26px;
+      height: 26px;
+      margin-top: 30px;
+      border: 1.5px solid rgba(255, 255, 255, 0.12);
+      border-top-color: rgba(255, 255, 255, 0.55);
       border-radius: 50%;
-      animation: spin 1.1s linear infinite;
+      animation: spin 1s linear infinite;
     }
-
     @keyframes spin { to { transform: rotate(360deg); } }
+    #state-ended .state-message { color: rgba(255, 255, 255, 0.6); }
 
-    /* Active state — credit roll viewer (reuses webrtc.html caption styles) */
-    #state-active {
-      align-items: stretch;
-      justify-content: stretch;
-      padding: 0;
-    }
+    /* Active state — caption teleprompter */
+    #state-active { align-items: stretch; justify-content: stretch; padding: 0; }
 
-    /* #91: 스크롤 컨테이너는 flex 를 쓰지 않는다 — flex 정렬(flex-end/
-       center)은 내용이 넘칠 때 시작 방향 오버플로를 스크롤로 도달 불가하게
-       만든다. 하단 고정 느낌은 .caption-container 의 min-height + flex-end
-       로 낸다. */
+    /* #91: scroll container must not use flex-end alignment (overflow becomes
+       unreachable). Bottom-anchored feel comes from min-height + flex-end on
+       the inner container. */
     #viewer {
       width: 100%;
       height: 100%;
@@ -160,87 +170,81 @@
       scrollbar-width: none;
       -ms-overflow-style: none;
     }
-
     #viewer::-webkit-scrollbar { display: none; }
 
     .caption-container {
       width: 100%;
-      max-width: 1100px;
+      max-width: 1040px;
       margin: 0 auto;
       min-height: 100%;
-      padding: 24px 20px 80px;
+      padding: 48px 40px 104px;
       display: flex;
       flex-direction: column;
       justify-content: flex-end;
-      gap: 12px;
-      /* #91: .state 의 text-align: center 상속 차단 — 자막은 좌측 정렬 */
-      text-align: left;
+      gap: 26px;
+      text-align: left; /* #91: block .state center inheritance */
     }
 
+    /* No cards. Past lines dim, current (last) line pure white. */
     .caption-line {
-      padding: 16px 22px;
-      border-radius: 14px;
-      background: rgba(255, 255, 255, 0.08);
-      border: 1px solid rgba(255, 255, 255, 0.15);
-      border-left: 4px solid #10b981;
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-      font-size: clamp(20px, 3.6vw, 30px);
+      font-size: clamp(24px, 3.4vw, 38px);
       font-weight: 500;
-      line-height: 1.45;
-      color: #ffffff;
-      max-width: 92%;
+      line-height: 1.5;
+      letter-spacing: -0.01em;
+      color: rgba(255, 255, 255, 0.42);
       word-break: keep-all;
       overflow-wrap: break-word;
-      animation: fade-in 0.35s ease-out;
+      transition: color 0.5s ease;
+      animation: rise 0.45s cubic-bezier(0.22, 1, 0.36, 1);
     }
+    .caption-container .caption-line:last-child { color: #ffffff; }
 
-    @keyframes fade-in {
-      from { opacity: 0; transform: translateY(8px); }
-      to { opacity: 1; transform: translateY(0); }
+    @keyframes rise {
+      from { opacity: 0; transform: translateY(10px); }
+      to   { opacity: 1; transform: translateY(0); }
     }
 
     .caption-empty {
-      color: rgba(255, 255, 255, 0.45);
-      font-size: clamp(16px, 2.5vw, 20px);
+      color: rgba(255, 255, 255, 0.32);
+      font-size: clamp(15px, 2vw, 18px);
       text-align: center;
       padding: 40px 20px;
+      letter-spacing: 0.01em;
     }
 
-    /* Ended state */
-    #state-ended .state-message { color: rgba(255, 255, 255, 0.7); }
-
+    /* Connection hint — subtle monochrome pill, not alarming */
     .conn-error {
       position: absolute;
-      bottom: 12px;
+      bottom: 16px;
       left: 50%;
       transform: translateX(-50%);
-      padding: 8px 14px;
-      border-radius: 10px;
-      background: rgba(245, 158, 11, 0.15);
-      border: 1px solid rgba(245, 158, 11, 0.4);
-      color: #fbbf24;
-      font-size: 13px;
+      padding: 7px 16px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.07);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      color: rgba(255, 255, 255, 0.65);
+      font-size: 12px;
+      letter-spacing: 0.02em;
       display: none;
     }
-
     .conn-error.visible { display: block; }
 
-    /* Mobile tweaks */
     @media (max-width: 600px) {
-      .topbar { padding: 10px 14px; }
-      .room-name { font-size: 13px; max-width: 50%; }
-      #lang-select { font-size: 14px; padding: 8px 10px; min-height: 44px; }
-      .caption-container { padding: 16px 14px 60px; }
-      .caption-line { padding: 12px 16px; }
+      .topbar { padding: 14px 18px; }
+      .lang-control label { display: none; }
+      .caption-container { padding: 28px 22px 72px; gap: 20px; }
     }
   </style>
 </head>
 <body>
   <main class="app" role="main">
     <header class="topbar">
-      <div class="room-name" id="room-name">{{ROOM_NAME}}</div>
+      <div class="room-meta">
+        <span class="live-dot" id="live-dot" aria-hidden="true"></span>
+        <div class="room-name" id="room-name">{{ROOM_NAME}}</div>
+      </div>
       <div class="lang-control">
-        <label for="lang-select">언어</label>
+        <label for="lang-select">Language</label>
         <select id="lang-select" aria-label="자막 언어 선택"></select>
       </div>
     </header>
@@ -296,6 +300,7 @@
     const captionEmpty = $("caption-empty");
     const connError = $("conn-error");
     const waitingRoom = $("waiting-room");
+    const liveDot = $("live-dot");
 
     waitingRoom.textContent = CONFIG.room_name || "";
 
@@ -336,6 +341,10 @@
       for (const [key, node] of Object.entries(stateNodes)) {
         node.classList.toggle("active", key === name);
       }
+    }
+
+    function setLive(on) {
+      liveDot.classList.toggle("live", !!on);
     }
 
     // ---------------------------------------------------------------------
@@ -388,6 +397,7 @@
 
     function showError(visible) {
       connError.classList.toggle("visible", !!visible);
+      if (visible) setLive(false);
     }
 
     function connect(lang) {
@@ -407,11 +417,12 @@
         return;
       }
 
-      es.addEventListener("open", () => showError(false));
+      es.addEventListener("open", () => { showError(false); setLive(true); });
 
       // The server emits explicit `event: message` and `event: session_end`.
       es.addEventListener("message", (ev) => {
         showError(false);
+        setLive(true);
         try {
           const payload = JSON.parse(ev.data);
           if (payload && typeof payload.text === "string") {
@@ -427,6 +438,7 @@
       });
 
       es.addEventListener("session_end", () => {
+        setLive(false);
         setState("ended");
         if (es) {
           try { es.close(); } catch (_) { /* noop */ }

--- a/components/webrtc.html
+++ b/components/webrtc.html
@@ -5,262 +5,238 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <style>
-    *, html {
-      box-sizing: border-box;
-    }
+    /* Minimal-dark operator view (design #109): near-black canvas, monochrome
+       captions (no cards/borders), thin ghost controls. Same language as
+       the viewer. All selectors preserved for JS hooks. */
+    *, html { box-sizing: border-box; }
 
-    html {
-      height: 100%;
-      margin: 0;
-      padding: 0;
-    }
+    html { height: 100%; margin: 0; padding: 0; }
 
     body {
       margin: 0;
-      padding: 5% 10px 10px 10px;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-      background: linear-gradient(135deg, #0f0f23 0%, #1a1a2e 50%, #16213e 100%);
+      padding: 4% 10px 10px 10px;
+      font-family: "Pretendard", -apple-system, BlinkMacSystemFont, "Segoe UI",
+        Roboto, "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+      background: #0b0b0c;
       color: #ffffff;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
       overflow: hidden !important;
       height: 100% !important;
       max-height: 100% !important;
-      box-sizing: border-box;
       position: relative;
     }
 
-    /* 🎨 동적 폰트 크기 CSS 변수 */
     :root {
       --translation-font-size: 28px;
       --original-font-size: 16px;
     }
 
-    /* 플로팅 설정 버튼 */
-    .settings-fab {
+    /* Floating controls — thin ghost circles */
+    .settings-fab, .fullscreen-fab {
       position: fixed;
-      top: calc(24px + 5%);
       right: 24px;
-      width: 56px;
-      height: 56px;
-      background: rgba(255, 255, 255, 0.15);
-      border: 1px solid rgba(255, 255, 255, 0.25);
+      width: 44px;
+      height: 44px;
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.12);
       border-radius: 50%;
       cursor: pointer;
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 24px;
+      color: rgba(255, 255, 255, 0.75);
       z-index: 1001;
-      backdrop-filter: blur(10px);
-      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+      backdrop-filter: blur(8px);
+      transition: background 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
     }
+    .settings-fab { top: calc(20px + 4%); }
+    .fullscreen-fab { top: calc(76px + 4%); }
+    .settings-fab svg, .fullscreen-fab svg { width: 20px; height: 20px; }
 
-    .settings-fab:hover {
-      background: rgba(255, 255, 255, 0.2);
-      transform: scale(1.1);
+    .settings-fab:hover, .fullscreen-fab:hover {
+      background: rgba(255, 255, 255, 0.1);
+      border-color: rgba(255, 255, 255, 0.25);
     }
-
     .settings-fab.active {
-      background: rgba(59, 130, 246, 0.3);
-      color: #3b82f6;
+      background: rgba(255, 255, 255, 0.14);
+      border-color: rgba(255, 255, 255, 0.35);
+      color: #ffffff;
     }
 
-    /* 설정 패널 */
+    /* Settings panel */
     .settings-panel {
       position: fixed;
       top: 0;
       right: 0;
       width: 380px;
       height: 100vh;
-      background: rgba(15, 15, 35, 0.95);
-      backdrop-filter: blur(20px);
-      border-left: 1px solid rgba(255, 255, 255, 0.1);
-      padding: 100px 28px 28px;
+      background: #0e0e10;
+      border-left: 1px solid rgba(255, 255, 255, 0.08);
+      padding: 88px 28px 28px;
       transform: translateX(100%);
       transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
       z-index: 1000;
-      box-shadow: -10px 0 50px rgba(0, 0, 0, 0.5);
+      box-shadow: -20px 0 60px rgba(0, 0, 0, 0.5);
       overflow-y: auto;
     }
-
-    .settings-panel.open {
-      transform: translateX(0);
-    }
+    .settings-panel.open { transform: translateX(0); }
 
     .settings-panel h2 {
       margin: 0 0 32px 0;
       color: #ffffff;
-      font-size: 24px;
-      font-weight: 300;
+      font-size: 20px;
+      font-weight: 500;
+      letter-spacing: -0.01em;
     }
 
-    .control-group {
-      margin-bottom: 32px;
-    }
-
+    .control-group { margin-bottom: 28px; }
     .control-group label {
       display: block;
       margin-bottom: 12px;
-      color: #a0a0a0;
-      font-size: 14px;
+      color: rgba(255, 255, 255, 0.5);
+      font-size: 12px;
       font-weight: 500;
-      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
     }
 
-    .control-group button {
+    .control-group button, .control-group select {
       width: 100%;
-      padding: 16px 20px;
-      border: 1px solid rgba(255, 255, 255, 0.15);
-      border-radius: 12px;
-      background: rgba(255, 255, 255, 0.08);
-      color: white;
+      padding: 14px 16px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      border-radius: 10px;
+      background: rgba(255, 255, 255, 0.04);
+      color: #ffffff;
       cursor: pointer;
       font-size: 15px;
       font-weight: 500;
-      transition: all 0.3s ease;
-      margin-bottom: 12px;
+      font-family: inherit;
+      transition: background 0.2s ease, border-color 0.2s ease;
     }
-
-    .control-group button:hover {
-      background: rgba(255, 255, 255, 0.15);
-      border-color: rgba(255, 255, 255, 0.3);
-      transform: translateY(-1px);
+    .control-group button { margin-bottom: 12px; }
+    .control-group button:hover, .control-group select:hover {
+      background: rgba(255, 255, 255, 0.09);
+      border-color: rgba(255, 255, 255, 0.24);
     }
-
     .control-group button:disabled {
-      opacity: 0.4;
+      opacity: 0.35;
       cursor: not-allowed;
-      transform: none;
     }
-
-    .control-group select {
-      width: 100%;
-      padding: 16px;
-      border: 1px solid rgba(255, 255, 255, 0.15);
-      border-radius: 12px;
-      background: rgba(255, 255, 255, 0.08);
-      color: white;
-      font-size: 15px;
-    }
+    .control-group select option { background: #151517; color: #ffffff; }
 
     .lang-warning {
       display: none;
-      margin-top: 6px;
+      margin-top: 8px;
       padding: 8px 12px;
       border-radius: 8px;
-      background: rgba(245, 158, 11, 0.15);
-      border: 1px solid rgba(245, 158, 11, 0.4);
-      color: #fbbf24;
+      background: rgba(255, 255, 255, 0.05);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      color: rgba(255, 255, 255, 0.65);
       font-size: 13px;
     }
+    .lang-warning.visible { display: block; }
 
-    .lang-warning.visible {
-      display: block;
-    }
-
-    /* 🎨 슬라이더 스타일링 */
+    /* Slider — monochrome */
     .slider {
       width: 100%;
-      height: 6px;
+      height: 3px;
       border-radius: 3px;
-      background: rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.12);
       outline: none;
-      margin: 8px 0 12px 0;
+      margin: 10px 0 12px 0;
       -webkit-appearance: none;
     }
-
     .slider::-webkit-slider-thumb {
       appearance: none;
-      width: 20px;
-      height: 20px;
+      -webkit-appearance: none;
+      width: 16px;
+      height: 16px;
       border-radius: 50%;
-      background: #10b981;
+      background: #ffffff;
       cursor: pointer;
-      transition: all 0.2s ease;
+      transition: transform 0.2s ease;
     }
-
-    .slider::-webkit-slider-thumb:hover {
-      background: #059669;
-      transform: scale(1.2);
-    }
-
+    .slider::-webkit-slider-thumb:hover { transform: scale(1.15); }
     .control-group span {
       display: inline-block;
       min-width: 60px;
-      color: #10b981;
+      color: rgba(255, 255, 255, 0.55);
       font-weight: 500;
       font-size: 13px;
     }
 
-    /* 상태 표시 */
+    /* Status — subtle pill with a single status dot */
     .status-overlay {
       position: absolute;
-      bottom: 32px;
-      left: 32px;
+      bottom: 28px;
+      left: 28px;
       display: flex;
-      gap: 16px;
+      gap: 12px;
       align-items: center;
       z-index: 999;
     }
-
     .status-chip {
-      padding: 12px 20px;
-      background: rgba(0, 0, 0, 0.6);
-      border: 1px solid rgba(255, 255, 255, 0.2);
-      border-radius: 25px;
-      font-size: 14px;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 9px 16px;
+      background: rgba(255, 255, 255, 0.05);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 999px;
+      font-size: 13px;
       font-weight: 500;
-      backdrop-filter: blur(10px);
-      transition: all 0.3s ease;
+      letter-spacing: 0.01em;
+      color: rgba(255, 255, 255, 0.7);
+      backdrop-filter: blur(8px);
+      transition: color 0.3s ease, border-color 0.3s ease;
     }
-
-    .status-chip.connected {
-      background: rgba(16, 185, 129, 0.2);
-      border-color: #10b981;
-      color: #10b981;
+    .status-chip::before {
+      content: "";
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.35);
+      transition: background 0.3s ease, box-shadow 0.3s ease;
     }
-
-    .status-chip.connecting {
-      background: rgba(59, 130, 246, 0.2);
-      border-color: #3b82f6;
-      color: #3b82f6;
-      animation: pulse 2s ease-in-out infinite;
+    .status-chip.connected { color: #ffffff; }
+    .status-chip.connected::before {
+      background: #4ade80;
+      box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.14);
     }
-
-    .status-chip.error {
-      background: rgba(239, 68, 68, 0.2);
-      border-color: #ef4444;
-      color: #ef4444;
+    .status-chip.connecting::before {
+      background: rgba(255, 255, 255, 0.7);
+      animation: pulse 1.6s ease-in-out infinite;
     }
+    .status-chip.error { color: rgba(255, 255, 255, 0.85); }
+    .status-chip.error::before { background: #f87171; }
 
-    /* 실시간으로 버튼 */
+    /* Back-to-live — monochrome pill */
     .back-to-live {
       position: absolute;
-      bottom: 32px;
-      right: 32px;
-      background: #10b981;
-      color: white;
-      border: none;
-      border-radius: 50px;
-      padding: 12px 20px;
-      font-size: 14px;
+      bottom: 28px;
+      right: 28px;
+      background: rgba(255, 255, 255, 0.1);
+      color: #ffffff;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: 999px;
+      padding: 10px 18px;
+      font-size: 13px;
       font-weight: 500;
       cursor: pointer;
       z-index: 998;
-      box-shadow: 0 4px 20px rgba(16, 185, 129, 0.3);
-      transition: all 0.3s ease;
+      backdrop-filter: blur(8px);
+      transition: background 0.25s ease, transform 0.25s ease;
       display: none;
       align-items: center;
       gap: 8px;
-      animation: bounce-gentle 2s ease-in-out infinite;
     }
-
     .back-to-live:hover {
-      background: #059669;
-      transform: translateY(-2px);
+      background: rgba(255, 255, 255, 0.18);
+      transform: translateY(-1px);
     }
 
-    /* 🎯 메인 캡션 뷰어 - 스크롤바 완전 숨김 */
+    /* Caption viewer */
     #viewer {
       height: 100% !important;
       max-height: 100% !important;
@@ -273,116 +249,75 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      scrollbar-width: none;        /* Firefox */
-      -ms-overflow-style: none;     /* IE and Edge */
+      scrollbar-width: none;
+      -ms-overflow-style: none;
       position: relative;
     }
+    #viewer::-webkit-scrollbar { display: none; }
 
-    #viewer::-webkit-scrollbar {
-      display: none;                /* Chrome, Safari */
-    }
-
-    /* 자막 컨테이너 */
     .caption-container {
       width: 100%;
-      max-width: 1200px;
-      padding: 10px 20px;
+      max-width: 1100px;
+      padding: 40px 48px 96px;
       display: flex;
       flex-direction: column;
       align-items: flex-start;
       gap: 0;
-      padding-bottom: 80px;
       min-height: 100%;
       box-sizing: border-box;
+      justify-content: center;
     }
 
+    /* No cards. Monochrome type only. */
     .caption-line {
-      margin-bottom: 16px;
-      line-height: 1.4;
-      padding: 16px 24px;
-      border-radius: 12px;
-      transition: all 0.4s ease;
+      margin-bottom: 24px;
+      line-height: 1.5;
+      padding: 0;
+      transition: color 0.4s ease, opacity 0.4s ease;
       word-break: keep-all;
       overflow-wrap: break-word;
-      max-width: 90%;
-      margin-left: 0;
-      margin-right: auto;
+      max-width: 100%;
       text-align: left;
-      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+      animation: fadeInUp 0.4s cubic-bezier(0.22, 1, 0.36, 1);
     }
 
-    /* 원문 스타일 */
+    /* Original (source) — small, dimmed */
     .caption-line.original {
       font-size: var(--original-font-size);
-      color: rgba(255, 255, 255, 0.6);
-      font-style: italic;
-      background: rgba(255, 255, 255, 0.03);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      border-left: 3px solid rgba(255, 255, 255, 0.4);
+      color: rgba(255, 255, 255, 0.38);
+      font-weight: 400;
       margin-bottom: 8px;
-      font-weight: 300;
-      max-width: 85%;
-      transition: all 0.3s ease;
-      padding: 12px 20px;
+      letter-spacing: 0;
     }
-
-    /* 원문 숨김 상태 */
-    .hide-original .caption-line.original {
-      display: none !important;
-    }
-
-    /* 번역문 숨김 상태 */
+    .hide-original .caption-line.original { display: none !important; }
     .hide-translation .caption-line.stable,
-    .hide-translation .caption-line.typing {
-      display: none !important;
-    }
+    .hide-translation .caption-line.typing { display: none !important; }
 
-    /* 번역된 자막 스타일 */
+    /* Confirmed translation — the hero line */
     .caption-line.stable {
       font-size: var(--translation-font-size);
       color: #ffffff;
-      font-weight: 500;
-      background: rgba(255, 255, 255, 0.08);
-      border: 1px solid rgba(255, 255, 255, 0.15);
-      border-left: 4px solid #10b981;
-      box-shadow:
-        0 8px 32px rgba(0, 0, 0, 0.3),
-        inset 0 1px 0 rgba(255, 255, 255, 0.1);
-      max-width: 90%;
+      font-weight: 600;
+      letter-spacing: -0.01em;
     }
 
-    /* 🎨 타이핑 중인 번역 말풍선 */
+    /* Typing translation — same as stable + subtle monochrome cursor */
     .caption-line.typing {
       font-size: var(--translation-font-size);
       color: #ffffff;
-      font-weight: 500;
-      background: rgba(255, 255, 255, 0.08);
-      border: 1px solid rgba(255, 255, 255, 0.15);
-      border-left: 4px solid #fbbf24;
-      box-shadow:
-        0 8px 32px rgba(0, 0, 0, 0.3),
-        inset 0 1px 0 rgba(255, 255, 255, 0.1);
-      max-width: 90%;
-      animation: typing-breathe 1.5s ease-in-out infinite;
+      font-weight: 600;
+      letter-spacing: -0.01em;
       position: relative;
     }
-
-    /* 타이핑 커서 효과 */
     .caption-line.typing::after {
-      content: '|';
-      color: #fbbf24;
+      content: '';
+      display: inline-block;
+      width: 2px;
+      height: 1em;
+      margin-left: 4px;
+      vertical-align: text-bottom;
+      background: rgba(255, 255, 255, 0.6);
       animation: cursor-blink 1s ease-in-out infinite;
-      margin-left: 2px;
-    }
-
-    @keyframes typing-breathe {
-      0%, 100% {
-        border-left-color: #fbbf24;
-      }
-      50% {
-        border-left-color: #f59e0b;
-        box-shadow: 0 8px 32px rgba(251, 191, 36, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.1);
-      }
     }
 
     @keyframes cursor-blink {
@@ -390,77 +325,28 @@
       51%, 100% { opacity: 0; }
     }
 
-    /* 실시간 입력 중 */
+    /* Interim (unstable) — dim, lighter weight */
     .caption-line.unstable {
       font-size: calc(var(--translation-font-size) - 2px);
-      color: #fbbf24;
-      font-style: italic;
+      color: rgba(255, 255, 255, 0.5);
       font-weight: 400;
-      background: rgba(251, 191, 36, 0.1);
-      border: 1px solid rgba(251, 191, 36, 0.3);
-      border-left: 4px solid #fbbf24;
-      animation: breathe 2s ease-in-out infinite;
-      max-width: 88%;
     }
 
-    @keyframes breathe {
-      0%, 100% { opacity: 0.8; transform: scale(1); }
-      50% { opacity: 1; transform: scale(1.02); }
-    }
-
-    /* 🎨 말풍선 등장 애니메이션 */
-    .caption-line.fade-in {
-      animation: fadeInUp 0.4s ease-out forwards;
-    }
-
+    .caption-line.fade-in { animation: fadeInUp 0.4s ease-out forwards; }
     @keyframes fadeInUp {
-      from {
-        opacity: 0;
-        transform: translateY(20px);
-      }
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
+      from { opacity: 0; transform: translateY(12px); }
+      to { opacity: 1; transform: translateY(0); }
     }
-
     @keyframes bounce-gentle {
       0%, 100% { transform: translateY(0px); }
       50% { transform: translateY(-4px); }
     }
-
     @keyframes pulse {
       0%, 100% { opacity: 1; }
-      50% { opacity: 0.7; }
+      50% { opacity: 0.4; }
     }
 
-    /* 전체화면 FAB 버튼 */
-    .fullscreen-fab {
-      position: fixed;
-      top: calc(90px + 5%);
-      right: 24px;
-      width: 56px;
-      height: 56px;
-      background: rgba(255, 255, 255, 0.15);
-      border: 1px solid rgba(255, 255, 255, 0.25);
-      border-radius: 50%;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 22px;
-      z-index: 1001;
-      backdrop-filter: blur(10px);
-      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-    }
-
-    .fullscreen-fab:hover {
-      background: rgba(255, 255, 255, 0.2);
-      transform: scale(1.1);
-    }
-
-    /* 전체화면 폰트 조절 컨트롤 */
+    /* Fullscreen font controls */
     .fs-font-controls {
       display: none;
       position: fixed;
@@ -471,70 +357,41 @@
       transition: opacity 0.4s ease;
       user-select: none;
     }
-
-    .fs-font-controls:hover,
-    .fs-font-controls:focus-within {
-      opacity: 1.0;
-    }
-
+    .fs-font-controls:hover, .fs-font-controls:focus-within { opacity: 1; }
     .fs-font-group {
       display: flex;
       align-items: center;
       gap: 6px;
       margin-bottom: 8px;
     }
-
-    .fs-font-group:last-child {
-      margin-bottom: 0;
-    }
-
+    .fs-font-group:last-child { margin-bottom: 0; }
     .fs-font-label {
-      color: #fff;
+      color: rgba(255, 255, 255, 0.6);
       font-size: 11px;
       min-width: 28px;
       text-align: right;
     }
-
     .fs-font-btn {
-      width: 44px;
-      height: 44px;
-      border: 1px solid rgba(255, 255, 255, 0.3);
+      width: 40px;
+      height: 40px;
+      border: 1px solid rgba(255, 255, 255, 0.16);
       border-radius: 8px;
-      background: rgba(0, 0, 0, 0.5);
+      background: rgba(0, 0, 0, 0.4);
       color: #fff;
       font-size: 18px;
       cursor: pointer;
       display: flex;
       align-items: center;
       justify-content: center;
-      transition: all 0.2s ease;
+      transition: background 0.2s ease, border-color 0.2s ease;
       padding: 0;
       line-height: 1;
     }
-
     .fs-font-btn:hover {
-      background: rgba(255, 255, 255, 0.2);
-      border-color: rgba(255, 255, 255, 0.5);
+      background: rgba(255, 255, 255, 0.14);
+      border-color: rgba(255, 255, 255, 0.32);
     }
-
-    .fs-font-btn:active {
-      transform: scale(0.9);
-    }
-
-    /* 키보드 포커스 표시 (WCAG 2.4.7) */
-    .settings-fab:focus-visible,
-    .fullscreen-fab:focus-visible,
-    .fs-font-btn:focus-visible {
-      outline: 2px solid #3b82f6;
-      outline-offset: 2px;
-      box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.3);
-    }
-
-    .settings-fab:focus:not(:focus-visible),
-    .fullscreen-fab:focus:not(:focus-visible) {
-      outline: none;
-    }
-
+    .fs-font-btn:active { transform: scale(0.92); }
     .fs-font-size {
       color: rgba(255, 255, 255, 0.7);
       font-size: 11px;
@@ -542,247 +399,135 @@
       text-align: center;
     }
 
-    /* 전체화면 상태 */
-    #viewer:fullscreen {
-      background: #000;
-      height: 100vh !important;
-      max-height: 100vh !important;
-      padding: 20px;
+    /* Focus (WCAG 2.4.7) — monochrome ring */
+    .settings-fab:focus-visible,
+    .fullscreen-fab:focus-visible,
+    .fs-font-btn:focus-visible {
+      outline: none;
+      border-color: rgba(255, 255, 255, 0.7);
+      box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.16);
     }
+    .settings-fab:focus:not(:focus-visible),
+    .fullscreen-fab:focus:not(:focus-visible) { outline: none; }
 
-    #viewer:fullscreen .caption-container {
-      max-width: 100%;
-      padding: 20px 40px;
-      padding-bottom: 100px;
-    }
+    /* Fullscreen */
+    #viewer:fullscreen { background: #000; height: 100vh !important; max-height: 100vh !important; padding: 20px; }
+    #viewer:fullscreen .caption-container { max-width: 100%; padding: 20px 56px 100px; }
+    #viewer:fullscreen .fs-font-controls { display: flex; flex-direction: column; }
+    #viewer:fullscreen .welcome-state { color: rgba(255, 255, 255, 0.8); }
+    #viewer:-webkit-full-screen { background: #000; height: 100vh !important; max-height: 100vh !important; padding: 20px; }
+    #viewer:-webkit-full-screen .caption-container { max-width: 100%; padding: 20px 56px 100px; }
+    #viewer:-webkit-full-screen .fs-font-controls { display: flex; flex-direction: column; }
 
-    #viewer:fullscreen .fs-font-controls {
-      display: flex;
-      flex-direction: column;
-    }
-
-    #viewer:fullscreen .welcome-state {
-      color: rgba(255, 255, 255, 0.8);
-    }
-
-    /* webkit prefix for Safari */
-    #viewer:-webkit-full-screen {
-      background: #000;
-      height: 100vh !important;
-      max-height: 100vh !important;
-      padding: 20px;
-    }
-
-    #viewer:-webkit-full-screen .caption-container {
-      max-width: 100%;
-      padding: 20px 40px;
-      padding-bottom: 100px;
-    }
-
-    #viewer:-webkit-full-screen .fs-font-controls {
-      display: flex;
-      flex-direction: column;
-    }
-
-    /* 빈 상태 */
+    /* Welcome / idle screen */
     .welcome-state {
       text-align: center;
       color: rgba(255, 255, 255, 0.7);
-      max-width: 600px;
+      max-width: 560px;
       margin: 0 auto;
-      padding: 60px 20px;
+      padding: 40px 20px;
     }
-
     .welcome-state .icon {
-      font-size: 80px;
-      margin-bottom: 32px;
-      opacity: 0.8;
-      filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.3));
+      color: rgba(255, 255, 255, 0.5);
+      margin-bottom: 28px;
+      display: flex;
+      justify-content: center;
     }
-
-    .welcome-state h1 {
-      font-size: 36px;
-      font-weight: 300;
-      margin-bottom: 16px;
+    .welcome-state .icon svg { width: 44px; height: 44px; }
+    .welcome-state h1, .welcome-title {
+      font-size: clamp(26px, 3.4vw, 34px);
+      font-weight: 500;
+      letter-spacing: -0.02em;
+      margin-bottom: 14px;
       color: #ffffff;
     }
-
-    .welcome-state p {
-      font-size: 18px;
-      color: rgba(255, 255, 255, 0.6);
-      margin-bottom: 32px;
+    .welcome-state p, .welcome-desc {
+      font-size: 16px;
+      color: rgba(255, 255, 255, 0.5);
+      margin-bottom: 28px;
       line-height: 1.6;
     }
-
     .welcome-state .hint {
-      font-size: 14px;
+      font-size: 13px;
       color: rgba(255, 255, 255, 0.4);
       display: flex;
       align-items: center;
       justify-content: center;
       gap: 8px;
     }
+    .welcome-rules {
+      margin-top: 18px;
+      font-size: 13px;
+      color: rgba(255, 255, 255, 0.4);
+      line-height: 1.7;
+    }
 
-    /* ISSUE-32: 행사장 QR 코드 — 시작 전 스크린에 크게 표시. */
+    /* QR — white card kept for scannability, refined framing */
     .qr-code-container {
-      display: none; /* JS 가 BOOT.qr_data_url 있을 때만 보여줌 */
-      margin: 24px auto 0;
-      padding: 16px;
-      background: #ffffff; /* QR 인식률을 위해 흰 배경 강제 */
-      border-radius: 12px;
+      display: none; /* JS shows it when BOOT.qr_data_url exists */
+      margin: 32px auto 0;
+      padding: 20px;
+      background: #ffffff;
+      border-radius: 18px;
       width: max-content;
       max-width: 90%;
-      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
     }
     .qr-code-container img {
       display: block;
-      margin: 0 auto; /* 캡션이 더 넓을 때도 QR 이 카드 중앙에 오도록 */
-      width: 240px;
-      height: 240px;
+      margin: 0 auto;
+      width: 220px;
+      height: 220px;
       max-width: 60vmin;
       max-height: 60vmin;
+      border-radius: 6px;
     }
     .qr-code-caption {
-      margin-top: 12px;
-      font-size: 13px;
-      /* 카드가 흰 배경이므로 어두운 글자여야 보인다 */
-      color: rgba(0, 0, 0, 0.65);
+      margin: 14px auto 0;
+      font-size: 12px;
+      color: rgba(0, 0, 0, 0.5);
       text-align: center;
       word-break: break-all;
-      max-width: 360px;
-      margin-left: auto;
-      margin-right: auto;
+      max-width: 320px;
+      line-height: 1.5;
     }
-    .qr-code-caption strong {
-      color: rgba(0, 0, 0, 0.9);
-    }
+    .qr-code-caption strong { color: rgba(0, 0, 0, 0.8); font-weight: 600; }
 
-    /* 반응형 디자인 - 너비 기준 */
+    /* Responsive — width */
     @media (max-width: 768px) {
-      body {
-        padding: 5% 5px 5px 5px;
-        height: 100% !important;
-        max-height: 100% !important;
-      }
-
-      .settings-panel {
-        width: 100%;
-      }
-
-      .caption-container {
-        padding: 5px 10px;
-        padding-bottom: 60px;
-      }
-
-      .caption-line {
-        margin-bottom: 12px;
-        padding: 12px 16px;
-      }
-
-      .caption-line.stable, .caption-line.typing {
-        font-size: calc(var(--translation-font-size) * 0.8);
-        max-width: 95%;
-      }
-
-      .caption-line.original {
-        font-size: calc(var(--original-font-size) * 0.9);
-        padding: 8px 12px;
-        margin-bottom: 6px;
-      }
-
-      .status-overlay {
-        bottom: 10px;
-        left: 10px;
-      }
-
-      .back-to-live {
-        bottom: 10px;
-        right: 10px;
-        padding: 8px 16px;
-        font-size: 12px;
-      }
-
-      .settings-fab {
-        top: calc(10px + 5%);
-        right: 10px;
-        width: 48px;
-        height: 48px;
-        font-size: 20px;
-      }
-
-      .fullscreen-fab {
-        top: calc(68px + 5%);
-        right: 10px;
-        width: 48px;
-        height: 48px;
-        font-size: 18px;
-      }
+      body { padding: 4% 5px 5px 5px; height: 100% !important; max-height: 100% !important; }
+      .settings-panel { width: 100%; }
+      .caption-container { padding: 24px 22px 64px; }
+      .caption-line { margin-bottom: 18px; }
+      .caption-line.stable, .caption-line.typing { font-size: calc(var(--translation-font-size) * 0.82); }
+      .caption-line.original { font-size: calc(var(--original-font-size) * 0.92); margin-bottom: 6px; }
+      .status-overlay { bottom: 14px; left: 14px; }
+      .back-to-live { bottom: 14px; right: 14px; padding: 8px 14px; font-size: 12px; }
+      .settings-fab { top: calc(12px + 4%); right: 12px; width: 42px; height: 42px; }
+      .fullscreen-fab { top: calc(64px + 4%); right: 12px; width: 42px; height: 42px; }
     }
 
-    /* 높이 기준 미디어쿼리 - 더 컴팩트 */
+    /* Responsive — short height */
     @media (max-height: 600px) {
-      body {
-        padding: 2% 5px 5px 5px;
-        height: 100% !important;
-        max-height: 100% !important;
-      }
-
-      .caption-container {
-        padding: 5px 10px;
-        padding-bottom: 40px;
-      }
-
-      .caption-line {
-        margin-bottom: 8px;
-        padding: 8px 12px;
-        line-height: 1.3;
-      }
-
-      .caption-line.original {
-        margin-bottom: 4px;
-        padding: 6px 10px;
-      }
-
-      .settings-panel {
-        padding: 40px 15px 15px;
-      }
-
-      .status-overlay {
-        bottom: 5px;
-        left: 5px;
-      }
-
-      .back-to-live {
-        bottom: 5px;
-        right: 5px;
-        padding: 6px 12px;
-        font-size: 11px;
-      }
-
-      .settings-fab {
-        top: calc(5px + 5%);
-        right: 5px;
-        width: 40px;
-        height: 40px;
-        font-size: 18px;
-      }
-
-      .fullscreen-fab {
-        top: calc(50px + 5%);
-        right: 5px;
-        width: 40px;
-        height: 40px;
-        font-size: 16px;
-      }
+      body { padding: 2% 5px 5px 5px; height: 100% !important; max-height: 100% !important; }
+      .caption-container { padding: 16px 22px 40px; }
+      .caption-line { margin-bottom: 12px; line-height: 1.35; }
+      .caption-line.original { margin-bottom: 4px; }
+      .settings-panel { padding: 40px 16px 16px; }
+      .status-overlay { bottom: 8px; left: 8px; }
+      .back-to-live { bottom: 8px; right: 8px; padding: 6px 12px; font-size: 11px; }
+      .settings-fab { top: calc(6px + 4%); right: 8px; width: 38px; height: 38px; }
+      .fullscreen-fab { top: calc(50px + 4%); right: 8px; width: 38px; height: 38px; }
     }
+
   </style>
 </head>
 
 <body>
   <!-- 플로팅 설정 버튼 -->
-  <button class="settings-fab" id="settingsFab" aria-label="설정" aria-expanded="false" aria-controls="settingsPanel">⚙️</button>
+  <button class="settings-fab" id="settingsFab" aria-label="설정" aria-expanded="false" aria-controls="settingsPanel"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></button>
   <!-- 전체화면 버튼 -->
-  <button class="fullscreen-fab" id="fullscreenFab" aria-label="전체화면" title="전체화면">⛶</button>
+  <button class="fullscreen-fab" id="fullscreenFab" aria-label="전체화면" title="전체화면"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"/></svg></button>
 
   <!-- 설정 패널 -->
   <div class="settings-panel" id="settingsPanel" role="region" aria-label="실시간 자막 설정">
@@ -790,7 +535,7 @@
 
     <div class="control-group">
       <label>마이크 권한</label>
-      <button id="btnPerm">🎤 마이크 권한 요청</button>
+      <button id="btnPerm">마이크 권한 요청</button>
     </div>
 
     <div class="control-group">
@@ -801,7 +546,7 @@
     </div>
 
     <div class="control-group">
-      <label>🗣️ 입력 언어</label>
+      <label>입력 언어</label>
       <select id="selInputLang">
         <option value="auto">자동 감지</option>
         <option value="ko">한국어</option>
@@ -812,7 +557,7 @@
     </div>
 
     <div class="control-group">
-      <label>🌐 출력 언어</label>
+      <label>출력 언어</label>
       <select id="selOutputLang">
         <option value="ko">한국어</option>
         <option value="zh">중국어</option>
@@ -824,13 +569,13 @@
 
     <!-- 🎨 폰트 크기 조절 -->
     <div class="control-group">
-      <label>📝 번역 글자 크기</label>
+      <label>번역 글자 크기</label>
       <input type="range" id="fontSizeSlider" min="18" max="48" value="28" step="2" class="slider">
       <span id="fontSizeValue">28px</span>
     </div>
 
     <div class="control-group">
-      <label>📄 원문 글자 크기</label>
+      <label>원문 글자 크기</label>
       <input type="range" id="originalSizeSlider" min="12" max="24" value="16" step="1" class="slider">
       <span id="originalSizeValue">16px</span>
     </div>
@@ -839,7 +584,7 @@
     <div class="control-group">
       <label style="display: flex; align-items: center; cursor: pointer;">
         <input type="checkbox" id="showOriginalToggle" style="margin-right: 8px; width: 16px; height: 16px;">
-        <span>🔤 원문 표시</span>
+        <span>원문 표시</span>
       </label>
     </div>
 
@@ -847,13 +592,13 @@
     <div class="control-group">
       <label style="display: flex; align-items: center; cursor: pointer;">
         <input type="checkbox" id="showTranslationToggle" style="margin-right: 8px; width: 16px; height: 16px;">
-        <span>🌐 번역문 표시</span>
+        <span>번역문 표시</span>
       </label>
     </div>
 
     <!-- ISSUE-32 AC4: 설정 패널에서도 QR 코드를 다시 확인할 수 있게 노출. -->
     <div class="control-group" id="settingsQrGroup" style="display: none;">
-      <label>📱 뷰어 QR 코드</label>
+      <label>뷰어 QR 코드</label>
       <div class="qr-code-container" data-qr-container style="margin: 8px auto 0; padding: 12px;">
         <img data-qr-img alt="자막을 볼 수 있는 뷰어 페이지로 이동하는 QR 코드"
              style="width: 160px; height: 160px;">
@@ -874,8 +619,7 @@
 
   <!-- 실시간으로 버튼 -->
   <button class="back-to-live" id="backToLive">
-    📺 실시간으로
-    <span style="margin-left: 4px;">⬇️</span>
+    실시간으로
   </button>
 
   <!-- 메인 캡션 뷰어 -->
@@ -897,22 +641,20 @@
     </div>
     <div class="caption-container" id="captionContainer">
       <div class="welcome-state">
-        <div class="icon">🎙️</div>
+        <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg></div>
         <h1 class="welcome-title">실시간 다국어 자막</h1>
         <p class="welcome-desc">말하면 실시간 자막과 번역이 나타납니다</p>
         <div class="hint">
-          <span>⚙️</span>
           <span>우상단 설정에서 마이크를 활성화하세요</span>
         </div>
-        <div class="welcome-rules" style="margin-top: 16px; font-size: 14px; color: rgba(255, 255, 255, 0.5);">
-          <div>🔄 번역 규칙:</div>
-          <div>• 감지된 언어 → 한국어</div>
+        <div class="welcome-rules">
+          감지된 언어를 한국어로 번역합니다
         </div>
         <!-- ISSUE-32: 행사장 QR 코드 — JS 가 BOOT.qr_data_url 있을 때만 보여줌. -->
         <div class="qr-code-container" data-qr-container>
           <img data-qr-img alt="자막을 볼 수 있는 뷰어 페이지로 이동하는 QR 코드">
           <div class="qr-code-caption">
-            📱 카메라로 스캔해 자막을 보세요<br>
+            카메라로 스캔하면 자막을 볼 수 있습니다<br>
             <strong data-qr-url></strong>
           </div>
         </div>
@@ -1104,7 +846,7 @@ try {
     // BOOT.room_name 이 비어있는 경로(관리자/단일 룸)에서는 기존 문구를
     // 그대로 유지해 회귀를 막는다.
     if (BOOT.room_name) {
-      title = `🎙️ ${BOOT.room_name} — ${title}`;
+      title = `${BOOT.room_name} — ${title}`;
     }
 
     // 설명 동적 변경
@@ -1115,12 +857,12 @@ try {
       desc = `${inputName}로 말하면<br>실시간 ${outputName} 자막이 나타납니다`;
     }
 
-    // 번역 규칙 동적 변경
+    // 번역 규칙 동적 변경 (미니멀: 한 줄 문구, 이모지 없음)
     let rulesHtml;
     if (inputVal === 'auto') {
-      rulesHtml = `<div>🔄 번역 규칙:</div><div>• 감지된 언어 → ${outputName}</div>`;
+      rulesHtml = `감지된 언어를 ${outputName}로 번역합니다`;
     } else {
-      rulesHtml = `<div>🔄 번역 규칙:</div><div>• ${inputName} → ${outputName}</div>`;
+      rulesHtml = `${inputName} → ${outputName} 번역`;
     }
 
     rulesContainers.forEach(ws => {
@@ -1628,22 +1370,20 @@ try {
   function clearViewer() {
     captionContainer.innerHTML = `
       <div class="welcome-state">
-        <div class="icon">🎙️</div>
+        <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg></div>
         <h1 class="welcome-title">실시간 다국어 자막</h1>
         <p class="welcome-desc">말하면 실시간 자막과 번역이 나타납니다</p>
         <div class="hint">
-          <span>⚙️</span>
           <span>우상단 설정에서 마이크를 활성화하세요</span>
         </div>
-        <div class="welcome-rules" style="margin-top: 16px; font-size: 14px; color: rgba(255, 255, 255, 0.5);">
-          <div>🔄 번역 규칙:</div>
-          <div>• 감지된 언어 → 한국어</div>
+        <div class="welcome-rules">
+          감지된 언어를 한국어로 번역합니다
         </div>
         <!-- ISSUE-32: 행사장 QR 코드 — clearViewer 후에도 동일하게 노출. -->
         <div class="qr-code-container" data-qr-container>
           <img data-qr-img alt="자막을 볼 수 있는 뷰어 페이지로 이동하는 QR 코드">
           <div class="qr-code-caption">
-            📱 카메라로 스캔해 자막을 보세요<br>
+            카메라로 스캔하면 자막을 볼 수 있습니다<br>
             <strong data-qr-url></strong>
           </div>
         </div>


### PR DESCRIPTION
## 요약
두 화면을 글로벌 컨퍼런스 톤(미니멀 다크, 무채색)으로 리디자인. 기능/JS 훅/템플릿 변수 전부 보존, CSS+마크업 톤만 변경.

Closes #109

## 변경
- **테마**: 네이비+퍼플 그라데이션 + 초록 액센트 + 이모지 → **#0b0b0c 근검정 + 무채색 + 얇은 SVG**
- **자막**: 카드/테두리/그림자 제거 → 텔레프롬프터식 순수 텍스트 (지난 줄 회색, 현재 줄 순백)
- **상단바/상태**: 얇은 헤어라인, 상태점 하나(연결 시 옅은 그린), 고스트 컨트롤
- **오퍼레이터**: `<style>` 전면 교체(셀렉터 보존), 이모지 → SVG, JS 웰컴 템플릿(clearViewer/updateWelcomeTranslationRules) 동기화

## 검증
- 단위 **671 passed**, E2E fullscreen 14 + viewer 3 + room_id 2 통과
- Playwright 스크린샷으로 웰컴/QR/자막/뷰어 렌더 확인 (근검정 배경, 무카드 자막, 상태점, 우아한 QR 카드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)