### PR TITLE
design(ui): 디자인 2차 — 테마/언어셀렉터/언어동기화/현재줄강조/생성중 표시

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,3 +1,12 @@
+[theme]
+# 미니멀 다크 (#109/#111) — 로그인/사이드바 등 Streamlit chrome 을 임베드된
+# 캡션 컴포넌트(#0b0b0c)와 톤을 맞춘다. 액센트는 거의 무채색.
+base = "dark"
+primaryColor = "#e8e8e8"
+backgroundColor = "#0b0b0c"
+secondaryBackgroundColor = "#151517"
+textColor = "#fafafa"
+
 [server]
 # ALB/프록시 환경에서 HTTPS 지원
 enableXsrfProtection = true

--- a/auth.py
+++ b/auth.py
@@ -398,7 +398,7 @@ def display_login_form():
         )
 
         # 로딩 메시지 표시
-        st.info("🔄 로그인 처리 중...")
+        st.info("로그인 중...")
 
         # 0.5초 동안 처리 중 메시지 표시
         time.sleep(0.5)
@@ -425,7 +425,7 @@ def display_login_form():
         return False
 
     # 로그인 폼 표시
-    st.title("🔐 로그인")
+    st.title("로그인")
 
     with st.form("login_form"):
         username = st.text_input("사용자명")

--- a/components/viewer.html
+++ b/components/viewer.html
@@ -85,20 +85,25 @@
       text-overflow: ellipsis;
     }
 
-    .lang-control { display: flex; align-items: center; gap: 10px; }
+    .lang-control { display: flex; align-items: center; gap: 8px; }
     .lang-control label {
-      font-size: 11px;
-      text-transform: uppercase;
-      letter-spacing: 0.12em;
-      color: rgba(255, 255, 255, 0.35);
+      display: flex;
+      align-items: center;
+      color: rgba(255, 255, 255, 0.5);
     }
+    .lang-control label svg { width: 18px; height: 18px; }
 
     #lang-select {
       min-height: 40px; /* WCAG touch target (RL-010) */
-      padding: 8px 14px;
+      padding: 8px 34px 8px 14px; /* room for the chevron */
       border: 1px solid rgba(255, 255, 255, 0.14);
       border-radius: 8px;
-      background: transparent;
+      background-color: transparent;
+      /* custom chevron — appearance:none removes the native arrow (#111) */
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23cccccc' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 12px center;
+      background-size: 12px;
       color: #ffffff;
       font-size: 14px;
       font-family: inherit;
@@ -212,6 +217,35 @@
       letter-spacing: 0.01em;
     }
 
+    /* #111 visual clue: persistent "listening" dots at the bottom while the
+       stream is live, so new lines emerge above a steady presence rather than
+       appearing from nothing. Sits outside .caption-container to avoid
+       clashing with the current-line (:last-child) highlight. */
+    .listening-indicator {
+      position: absolute;
+      bottom: 24px;
+      left: 50%;
+      transform: translateX(-50%);
+      display: none;
+      align-items: center;
+      gap: 7px;
+      pointer-events: none;
+    }
+    .listening-indicator.live { display: flex; }
+    .listening-indicator span {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.3);
+      animation: dot-pulse 1.4s ease-in-out infinite;
+    }
+    .listening-indicator span:nth-child(2) { animation-delay: 0.2s; }
+    .listening-indicator span:nth-child(3) { animation-delay: 0.4s; }
+    @keyframes dot-pulse {
+      0%, 100% { opacity: 0.2; transform: translateY(0); }
+      50% { opacity: 0.9; transform: translateY(-3px); }
+    }
+
     /* Connection hint — subtle monochrome pill, not alarming */
     .conn-error {
       position: absolute;
@@ -231,7 +265,6 @@
 
     @media (max-width: 600px) {
       .topbar { padding: 14px 18px; }
-      .lang-control label { display: none; }
       .caption-container { padding: 28px 22px 72px; gap: 20px; }
     }
   </style>
@@ -244,7 +277,7 @@
         <div class="room-name" id="room-name">{{ROOM_NAME}}</div>
       </div>
       <div class="lang-control">
-        <label for="lang-select">Language</label>
+        <label for="lang-select" title="언어 선택"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg></label>
         <select id="lang-select" aria-label="자막 언어 선택"></select>
       </div>
     </header>
@@ -261,6 +294,9 @@
           <div class="caption-container" id="captionContainer">
             <div class="caption-empty" id="caption-empty">자막을 기다리는 중…</div>
           </div>
+        </div>
+        <div class="listening-indicator" id="listening-indicator" aria-hidden="true">
+          <span></span><span></span><span></span>
         </div>
       </section>
 
@@ -301,6 +337,7 @@
     const connError = $("conn-error");
     const waitingRoom = $("waiting-room");
     const liveDot = $("live-dot");
+    const listeningIndicator = $("listening-indicator");
 
     waitingRoom.textContent = CONFIG.room_name || "";
 
@@ -345,6 +382,8 @@
 
     function setLive(on) {
       liveDot.classList.toggle("live", !!on);
+      // #111: 하단 "듣는 중" 점 인디케이터도 동기화.
+      if (listeningIndicator) listeningIndicator.classList.toggle("live", !!on);
     }
 
     // ---------------------------------------------------------------------

--- a/components/webrtc.html
+++ b/components/webrtc.html
@@ -294,14 +294,17 @@
     .hide-translation .caption-line.typing { display: none !important; }
 
     /* Confirmed translation — the hero line */
+    /* Confirmed translation — dim by default, only the current line is white
+       (#111): the latest sentence stands out, previous ones recede. */
     .caption-line.stable {
       font-size: var(--translation-font-size);
-      color: #ffffff;
+      color: rgba(255, 255, 255, 0.4);
       font-weight: 600;
       letter-spacing: -0.01em;
     }
+    .caption-line.stable.current { color: #ffffff; }
 
-    /* Typing translation — same as stable + subtle monochrome cursor */
+    /* Typing translation — current line, white + monochrome cursor */
     .caption-line.typing {
       font-size: var(--translation-font-size);
       color: #ffffff;
@@ -319,10 +322,27 @@
       background: rgba(255, 255, 255, 0.6);
       animation: cursor-blink 1s ease-in-out infinite;
     }
+    /* #111 visual clue: while a sentence is being formed (transcript in, but
+       translation not yet back), the empty typing bubble shows breathing dots
+       so lines never appear abruptly. */
+    .caption-line.typing:empty::after {
+      content: "· · ·";
+      width: auto;
+      height: auto;
+      margin-left: 0;
+      background: none;
+      color: rgba(255, 255, 255, 0.55);
+      letter-spacing: 0.15em;
+      animation: dots-breathe 1.4s ease-in-out infinite;
+    }
 
     @keyframes cursor-blink {
       0%, 50% { opacity: 1; }
       51%, 100% { opacity: 0; }
+    }
+    @keyframes dots-breathe {
+      0%, 100% { opacity: 0.35; }
+      50% { opacity: 1; }
     }
 
     /* Interim (unstable) — dim, lighter weight */
@@ -1247,8 +1267,13 @@ try {
 
   function completeTypingTranslation(text) {
     if (currentTypingLine) {
-      currentTypingLine.className = 'caption-line stable fade-in';
-      currentTypingLine.textContent = text;
+      const el = currentTypingLine;
+      // #111: 마지막 문장만 흰색 — 이전 current 를 모두 해제하고 이 줄에 부여.
+      captionContainer
+        .querySelectorAll('.caption-line.current')
+        .forEach((n) => n.classList.remove('current'));
+      el.className = 'caption-line stable fade-in current';
+      el.textContent = text;
       currentTypingLine = null;
     }
   }
@@ -1662,6 +1687,11 @@ try {
               timestamp: Date.now()
             }));
 
+            // #111: 번역이 서버에서 오는 동안(약 1초) 비어 보이지 않도록
+            // "생성 중" forming 버블(점 애니메이션)을 즉시 띄운다. 이후
+            // transcription_result 가 이 버블을 그대로 채운다.
+            startTypingTranslation();
+
             // 타이밍 변수 초기화
             speechStartTime = null;
             speechEndTime = null;
@@ -1701,11 +1731,13 @@ try {
       case 'transcription_result':
         // 번역된 텍스트가 있으면 표시
         if (data.translated_text && data.translated_text !== data.original_text) {
-          startTypingTranslation();
-          // 즉시 번역 완료 표시
-          setTimeout(() => {
-            completeTypingTranslation(data.translated_text);
-          }, 100);
+          // 전사 완료 시 미리 만들어 둔 forming 버블(생성중 점)을 그대로 채운다.
+          if (!currentTypingLine) startTypingTranslation();
+          completeTypingTranslation(data.translated_text);
+        } else if (currentTypingLine) {
+          // 번역이 원문과 동일(동일 언어) — 대기 중이던 forming 버블 제거.
+          currentTypingLine.remove();
+          currentTypingLine = null;
         }
 
         // 사용량 정보 업데이트 (Streamlit 부모 프레임에 메시지 전송)

--- a/tests/test_sse_broadcast.py
+++ b/tests/test_sse_broadcast.py
@@ -425,24 +425,24 @@ class TestLazyTranslationAndNonBlocking:
         )
 
         mgr = BroadcastManager()
-        # 메인 언어 ko, 추가 언어 ja (#103: secondary 는 SUPPORTED_OUTPUT_LANGS
-        # 기준이므로 ko/ja/zh/vi 중에서 고른다).
+        # 메인 언어 ko, 추가 언어 en (#111: secondary 는 SUPPORTED_OUTPUT_LANGS
+        # 기준이므로 ko/en/zh/vi 중에서 고른다).
         room = {
             "id": "r1",
             "primary_output_lang": "ko",
         }
         # 메인 + 추가 언어 모두 viewer 등록
         ko_q = await mgr.register_viewer("r1", "ko")
-        ja_q = await mgr.register_viewer("r1", "ja")
+        en_q = await mgr.register_viewer("r1", "en")
 
         slow_calls: list[str] = []
 
         async def fake_translate(text: str, src: str, dst: str) -> str:
-            if dst == "ja":
-                slow_calls.append("ja-start")
+            if dst == "en":
+                slow_calls.append("en-start")
                 await asyncio.sleep(0.5)  # secondary lang is artificially slow
-                slow_calls.append("ja-done")
-                return "こんにちは"
+                slow_calls.append("en-done")
+                return "Hello"
             return "안녕"  # primary path is fast
 
         translated_main = "안녕"
@@ -470,10 +470,10 @@ class TestLazyTranslationAndNonBlocking:
         assert "timestamp" in msg_main
 
         # Then the secondary message arrives later.
-        msg_secondary = await asyncio.wait_for(ja_q.get(), timeout=2.0)
-        assert msg_secondary["text"] == "こんにちは"
-        assert msg_secondary["lang"] == "ja"
-        assert "ja-done" in slow_calls
+        msg_secondary = await asyncio.wait_for(en_q.get(), timeout=2.0)
+        assert msg_secondary["text"] == "Hello"
+        assert msg_secondary["lang"] == "en"
+        assert "en-done" in slow_calls
 
     @pytest.mark.asyncio
     async def test_secondary_translation_skipped_when_no_viewers(self):
@@ -528,13 +528,13 @@ class TestLazyTranslationAndNonBlocking:
         )
 
         mgr = BroadcastManager()
-        # #103: secondary 는 SUPPORTED_OUTPUT_LANGS(ko/ja/zh/vi) 기준.
+        # #111: secondary 는 SUPPORTED_OUTPUT_LANGS(ko/en/zh/vi) 기준.
         room = {
             "id": "r1",
             "primary_output_lang": "ko",
         }
         await mgr.register_viewer("r1", "ko")
-        ja_q = await mgr.register_viewer("r1", "ja")
+        en_q = await mgr.register_viewer("r1", "en")
         # zh, vi 는 viewer 없음 — 번역 스킵 대상
 
         secondary_calls: list[str] = []
@@ -552,10 +552,10 @@ class TestLazyTranslationAndNonBlocking:
             translate_fn=fake_translate,
         )
 
-        msg = await asyncio.wait_for(ja_q.get(), timeout=2.0)
-        assert msg["text"] == "[ja]hi"
+        msg = await asyncio.wait_for(en_q.get(), timeout=2.0)
+        assert msg["text"] == "[en]hi"
         # zh, vi 는 호출되지 않음
-        assert secondary_calls == ["ja"], secondary_calls
+        assert secondary_calls == ["en"], secondary_calls
 
 
 # ---------------------------------------------------------------------------
@@ -809,15 +809,15 @@ class TestSupportedOutputLangs:
 
         result = _supported_output_langs("xx")
         assert result[0] == "xx"
-        assert "ko" in result and "ja" in result
+        assert "ko" in result and "en" in result
 
     def test_covers_langs_beyond_default_room_config(self):
         """기본 룸 설정(ko 뿐)이던 시절과 달리 지원 언어 전부 선택 가능."""
         from sse_broadcast import _supported_output_langs
 
         result = _supported_output_langs("ko")
-        # #103: 지원 언어는 ko/ja/zh/vi (전용 번역 프롬프트가 있는 것만).
-        for lang in ("ko", "ja", "zh", "vi"):
+        # #111: 지원 언어는 ko/en/zh/vi (operator 출력 언어와 싱크).
+        for lang in ("ko", "en", "zh", "vi"):
             assert lang in result
 
 

--- a/translation.py
+++ b/translation.py
@@ -18,15 +18,15 @@ SOURCE_LANG_NAMES = {
     "de": "독일어",
 }
 
-# 뷰어가 선택할 수 있는 자막 언어 (#91/#92, #103).
+# 뷰어가 선택할 수 있는 자막 언어 (#91/#92, #103, #111).
 # 룸별 output_langs 설정 대신 전역 고정 목록을 쓴다 — SSE lazy 게이트
 # (has_viewers)가 언어별 번역 비용을 이미 제어하므로 룸 제한이 불필요.
-# translate_with_llm 이 전용 프롬프트를 가진 언어만 포함한다 — 프롬프트가
-# 없으면 영어 기본값으로 잘못 번역되므로(#103), 목록과 프롬프트 커버리지를
-# 반드시 일치시킬 것.
+# translate_with_llm 이 커버하는 언어만 포함한다 (ko/zh/vi 전용 프롬프트,
+# en 은 _build_prompt_to_english). #111: operator 출력 언어(ko/zh/en/vi)와
+# 싱크 — en 추가, ja 제거.
 SUPPORTED_OUTPUT_LANGS: tuple[str, ...] = (
     "ko",
-    "ja",
+    "en",
     "zh",
     "vi",
 )


### PR DESCRIPTION
## 요약
디자인 1차(#109) 후속 5건.

Closes #111

## 변경
1. **Streamlit 다크 테마** (`.streamlit/config.toml`): 로그인·사이드바를 캡션 컴포넌트(#0b0b0c)와 통일. 로그인 이모지 제거.
2. **뷰어 언어 셀렉터**: 사라졌던 화살표 → 커스텀 셰브론, 라벨 → 지구본 SVG 아이콘(모바일에서도 표시).
3. **언어 동기화**: `SUPPORTED_OUTPUT_LANGS` en 추가·ja 제거 → 한국어/English/中文/Tiếng Việt (operator 출력과 싱크).
4. **operator 자막**: 마지막 문장만 흰색, 이전은 회색(`.current`) — 뷰어와 동일.
5. **생성 중 표시**: operator 는 전사 직후 forming 버블(점 애니메이션)로 번역 대기 구간을 메움, 뷰어는 하단 "듣는 중" 점 인디케이터.

## 검증
- 단위 **671 passed**, E2E fullscreen+viewer_page+room_id **19 passed**
- Playwright 스크린샷: 지구본+셰브론, en 목록(ja 없음), 현재 줄만 흰색, 생성중 점 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)