### PR TITLE
design(ui): 디자인 3차 — 사이드바/버튼/룸이름/대기문구/점/토스트

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,6 +60,21 @@ st.set_page_config(
     initial_sidebar_state=st.session_state["sidebar_state"],
 )
 
+# 전역 UI 테마 보정 (#112): 밝은 primaryColor 버튼(시작/로그인 등)은
+# 흰 배경이라 글자가 안 보인다 → 강제로 검은 글자. 로그인 화면에도
+# 적용되도록 인증 체크보다 먼저 주입한다.
+st.markdown(
+    """
+    <style>
+      button[kind="primary"], button[kind="primary"] *,
+      button[kind="primaryFormSubmit"], button[kind="primaryFormSubmit"] * {
+        color: #0b0b0c !important;
+      }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
 # 사용자 인증 체크
 init_session_state()
 
@@ -104,12 +119,12 @@ def _load_assigned_rooms_for_user(user):
 
 # === 사이드바 ===
 with st.sidebar:
-    st.header("🧑‍💻 유저 정보")
+    st.header("유저 정보")
     display_user_info()
 
     if not get_aws_access_key_id() or not get_aws_secret_access_key():
-        st.error("⚠️ AWS 자격 증명이 설정되지 않았습니다.")
-        st.info("💡 .env 파일에 AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY를 설정하세요")
+        st.error("AWS 자격 증명이 설정되지 않았습니다.")
+        st.info(".env 파일에 AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY를 설정하세요")
         st.stop()
 
     # 룸 선택 (오퍼레이터 전용, ISSUE-27) ----------------------------
@@ -123,7 +138,7 @@ with st.sidebar:
 
     if show_room_section:
         st.markdown("---")
-        st.subheader("🏛️ 배정된 룸")
+        st.subheader("배정된 룸")
         if has_assigned_rooms(assigned_rooms):
             options = build_room_dropdown_options(assigned_rooms)
             labels = [opt["label"] for opt in options]
@@ -155,7 +170,7 @@ with st.sidebar:
             st.session_state.pop("selected_room_name", None)
 
     # 시스템 제어
-    st.subheader("🎛️ 시스템 제어")
+    st.subheader("시스템 제어")
     col1, col2 = st.columns([1, 1])
 
     current_status = st.session_state.get("action", "idle")
@@ -174,7 +189,7 @@ with st.sidebar:
             or is_admin_role
         )
         start = st.button(
-            "🎯 시작",
+            "시작",
             type="primary",
             use_container_width=True,
             disabled=start_disabled,
@@ -197,36 +212,36 @@ with st.sidebar:
             "error",
         ]
         stop = st.button(
-            "⏹️ 정지",
+            "정지",
             use_container_width=True,
             disabled=stop_disabled,
         )
 
     # 시스템 상태
     st.markdown("---")
-    st.subheader("📊 시스템 상태")
+    st.subheader("시스템 상태")
     status = st.session_state.get("action", "idle")
     if status == "start":
-        st.success("🟢 서비스 실행 중")
-        st.info("💡 자막 세부 설정은 화면 우상단 ⚙️ 버튼을 클릭하세요")
+        st.success("서비스 실행 중")
+        st.info("자막 세부 설정은 화면 우상단 설정 버튼을 클릭하세요")
     elif status == "error":
-        st.error("🔴 오류 발생")
+        st.error("오류 발생")
     else:
-        st.info("🟡 대기 중")
+        st.info("대기 중")
 
     # WebSocket 포트 정보 표시
     ws_port = st.session_state["websocket_port_ref"]["port"]
     if ws_port:
         st.markdown("---")
-        st.subheader("🔗 연결 정보")
+        st.subheader("연결 정보")
         st.code(f"WebSocket: ws://localhost:{ws_port}")
         if (
             st.session_state.get("websocket_thread")
             and st.session_state["websocket_thread"].is_alive()
         ):
-            st.success("🟢 WebSocket 서버 실행 중")
+            st.success("WebSocket 서버 실행 중")
         else:
-            st.warning("🟡 WebSocket 서버 대기 중")
+            st.warning("WebSocket 서버 대기 중")
 
 
 # === WebSocket 서버 스레드 ===
@@ -302,7 +317,7 @@ if start and not is_admin_role:
             st.session_state["action"] = "start"
             st.rerun()
     except ValueError as e:
-        st.error(f"❌ {e!s}")
+        st.error(f"{e!s}")
         st.session_state["action"] = "error"
         st.session_state["sidebar_state"] = "expanded"
         st.rerun()
@@ -360,7 +375,7 @@ def _build_view_url_and_qr(room_id: str | None) -> tuple[str | None, str | None]
 # 번역이 실패하므로 (컴포넌트를 아예 렌더하지 않는다).
 if (get_current_user() or {}).get("role") == "admin":
     st.info(
-        "👋 관리자 계정입니다. 자막 세션은 룸이 배정된 오퍼레이터 계정에서 "
+        "관리자 계정입니다. 자막 세션은 룸이 배정된 오퍼레이터 계정에서 "
         "운영합니다. 사이드바의 **관리자 대시보드**에서 룸과 사용자를 관리하세요."
     )
 else:
@@ -391,4 +406,4 @@ else:
         st.components.v1.html(html_content, height=900, scrolling=False)
 
     except Exception:
-        st.error("❌ 시스템을 로드할 수 없습니다.")
+        st.error("시스템을 로드할 수 없습니다.")

--- a/components/viewer.html
+++ b/components/viewer.html
@@ -284,7 +284,7 @@
 
     <div class="main">
       <section id="state-waiting" class="state" aria-live="polite">
-        <div class="state-message">잠시 후 자막이 시작됩니다</div>
+        <div class="state-message">잠시 후 시작됩니다</div>
         <div class="state-room" id="waiting-room"></div>
         <div class="state-spinner" aria-hidden="true"></div>
       </section>
@@ -292,7 +292,7 @@
       <section id="state-active" class="state">
         <div id="viewer">
           <div class="caption-container" id="captionContainer">
-            <div class="caption-empty" id="caption-empty">자막을 기다리는 중…</div>
+            <div class="caption-empty" id="caption-empty">잠시 후 시작됩니다</div>
           </div>
         </div>
         <div class="listening-indicator" id="listening-indicator" aria-hidden="true">
@@ -371,6 +371,24 @@
       }
     })();
 
+    // #112: 대기/빈 상태 문구를 선택 언어로 표시 ("자막" 어절 제거).
+    const WAITING_MSG = {
+      ko: "잠시 후 시작됩니다",
+      en: "Starting shortly",
+      zh: "即将开始",
+      vi: "Sắp bắt đầu",
+    };
+    const waitingMsgEl = document.querySelector("#state-waiting .state-message");
+
+    function applyWaitingText(lang) {
+      const msg = WAITING_MSG[lang] || WAITING_MSG.ko;
+      if (waitingMsgEl) waitingMsgEl.textContent = msg;
+      const emptyEl = document.getElementById("caption-empty");
+      if (emptyEl) emptyEl.textContent = msg;
+    }
+
+    applyWaitingText(CONFIG.primary_lang || "ko");
+
     // ---------------------------------------------------------------------
     // State controller
     // ---------------------------------------------------------------------
@@ -424,7 +442,7 @@
       const empty = document.createElement("div");
       empty.id = "caption-empty";
       empty.className = "caption-empty";
-      empty.textContent = "자막을 기다리는 중…";
+      empty.textContent = WAITING_MSG[currentLang] || WAITING_MSG.ko;
       captionContainer.appendChild(empty);
     }
 
@@ -499,6 +517,8 @@
       if (!next || next === currentLang) return;
       clearCaptions();
       connect(next);
+      // #112: 대기/빈 문구를 새 언어로 갱신 (connect 이후 currentLang=next).
+      applyWaitingText(next);
     });
 
     // ---------------------------------------------------------------------

--- a/components/webrtc.html
+++ b/components/webrtc.html
@@ -304,7 +304,7 @@
     }
     .caption-line.stable.current { color: #ffffff; }
 
-    /* Typing translation — current line, white + monochrome cursor */
+    /* Typing / forming translation — current line, white */
     .caption-line.typing {
       font-size: var(--translation-font-size);
       color: #ffffff;
@@ -312,37 +312,27 @@
       letter-spacing: -0.01em;
       position: relative;
     }
-    .caption-line.typing::after {
-      content: '';
-      display: inline-block;
-      width: 2px;
-      height: 1em;
-      margin-left: 4px;
-      vertical-align: text-bottom;
-      background: rgba(255, 255, 255, 0.6);
-      animation: cursor-blink 1s ease-in-out infinite;
+    /* #111/#112 visual clue: while a sentence is being formed (transcript in,
+       translation not yet back), show breathing dots. Same size/rhythm as the
+       viewer's listening indicator (6px dots), spacing kept tight. */
+    .forming-dots {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      vertical-align: middle;
     }
-    /* #111 visual clue: while a sentence is being formed (transcript in, but
-       translation not yet back), the empty typing bubble shows breathing dots
-       so lines never appear abruptly. */
-    .caption-line.typing:empty::after {
-      content: "· · ·";
-      width: auto;
-      height: auto;
-      margin-left: 0;
-      background: none;
-      color: rgba(255, 255, 255, 0.55);
-      letter-spacing: 0.15em;
-      animation: dots-breathe 1.4s ease-in-out infinite;
+    .forming-dots span {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.5);
+      animation: dot-pulse 1.4s ease-in-out infinite;
     }
-
-    @keyframes cursor-blink {
-      0%, 50% { opacity: 1; }
-      51%, 100% { opacity: 0; }
-    }
-    @keyframes dots-breathe {
-      0%, 100% { opacity: 0.35; }
-      50% { opacity: 1; }
+    .forming-dots span:nth-child(2) { animation-delay: 0.2s; }
+    .forming-dots span:nth-child(3) { animation-delay: 0.4s; }
+    @keyframes dot-pulse {
+      0%, 100% { opacity: 0.2; transform: translateY(0); }
+      50% { opacity: 0.9; transform: translateY(-3px); }
     }
 
     /* Interim (unstable) — dim, lighter weight */
@@ -458,8 +448,15 @@
       font-size: clamp(26px, 3.4vw, 34px);
       font-weight: 500;
       letter-spacing: -0.02em;
-      margin-bottom: 14px;
+      margin-bottom: 10px;
       color: #ffffff;
+    }
+    /* #112: 룸 이름 — 제목 아래 별도 줄, 대시 없이 */
+    .welcome-room {
+      font-size: 14px;
+      letter-spacing: 0.03em;
+      color: rgba(255, 255, 255, 0.45);
+      margin-bottom: 24px;
     }
     .welcome-state p, .welcome-desc {
       font-size: 16px;
@@ -663,6 +660,7 @@
       <div class="welcome-state">
         <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg></div>
         <h1 class="welcome-title">실시간 다국어 자막</h1>
+        <div class="welcome-room" style="display: none;"></div>
         <p class="welcome-desc">말하면 실시간 자막과 번역이 나타납니다</p>
         <div class="hint">
           <span>우상단 설정에서 마이크를 활성화하세요</span>
@@ -862,12 +860,8 @@ try {
     } else {
       title = `실시간 ${inputName} → ${outputName} 자막`;
     }
-    // ISSUE-28 AC3: 운영자가 룸을 선택했을 때만 룸 이름을 타이틀에 합성한다.
-    // BOOT.room_name 이 비어있는 경로(관리자/단일 룸)에서는 기존 문구를
-    // 그대로 유지해 회귀를 막는다.
-    if (BOOT.room_name) {
-      title = `${BOOT.room_name} — ${title}`;
-    }
+    // #112: 룸 이름은 타이틀에 "룸 — 제목" 으로 붙이지 않고, 제목 아래
+    // 별도 줄(.welcome-room)에 보여준다. (ISSUE-28: 룸 선택 시에만 노출)
 
     // 설명 동적 변경
     let desc;
@@ -888,6 +882,11 @@ try {
     rulesContainers.forEach(ws => {
       const titleEl = ws.querySelector('.welcome-title');
       if (titleEl) titleEl.textContent = title;
+      const roomEl = ws.querySelector('.welcome-room');
+      if (roomEl) {
+        roomEl.textContent = BOOT.room_name || '';
+        roomEl.style.display = BOOT.room_name ? '' : 'none';
+      }
       const descEl = ws.querySelector('.welcome-desc');
       if (descEl) descEl.innerHTML = desc;
       const rulesDiv = ws.querySelector('.welcome-rules');
@@ -1223,25 +1222,14 @@ try {
 
   // 토스트 메시지
   function showToast(message, type = 'info') {
-    if (type === 'error' || type === 'warning') {
-      const toast = document.createElement('div');
-      toast.style.cssText = `
-        position: fixed; top: 24px; left: 50%;
-        transform: translateX(-50%);
-        background: ${type === 'error' ? '#ef4444' : '#f59e0b'};
-        color: white; padding: 16px 24px; border-radius: 12px;
-        box-shadow: 0 8px 32px rgba(0,0,0,0.3);
-        z-index: 1002; font-size: 14px; font-weight: 500;
-        opacity: 0; transition: opacity 0.3s ease;
-      `;
-      toast.textContent = message;
-      document.body.appendChild(toast);
-
-      setTimeout(() => toast.style.opacity = '1', 10);
-      setTimeout(() => {
-        toast.style.opacity = '0';
-        setTimeout(() => document.body.removeChild(toast), 300);
-      }, 3000);
+    // #112: 컨퍼런스 중 상단 토스트는 화면을 가려 방해가 된다. 진단은
+    // 콘솔로만 남기고 화면에는 띄우지 않는다.
+    if (type === 'error') {
+      console.error('[Toast]', message);
+    } else if (type === 'warning') {
+      console.warn('[Toast]', message);
+    } else {
+      console.log('[Toast]', message);
     }
   }
 
@@ -1252,7 +1240,11 @@ try {
     }
     currentTypingLine = document.createElement('div');
     currentTypingLine.className = 'caption-line typing fade-in';
-    currentTypingLine.textContent = '';
+    // #112: 생성 중 표시 — 뷰어와 동일한 점 인디케이터(촘촘한 간격).
+    // completeTypingTranslation/updateTypingTranslation 이 textContent 로
+    // 덮어쓰면 자동으로 사라진다.
+    currentTypingLine.innerHTML =
+      '<span class="forming-dots"><span></span><span></span><span></span></span>';
     captionContainer.appendChild(currentTypingLine);
 
     // 🎯 사용자 스크롤 상태 확인 후 자동 스크롤
@@ -1397,6 +1389,7 @@ try {
       <div class="welcome-state">
         <div class="icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg></div>
         <h1 class="welcome-title">실시간 다국어 자막</h1>
+        <div class="welcome-room" style="display: none;"></div>
         <p class="welcome-desc">말하면 실시간 자막과 번역이 나타납니다</p>
         <div class="hint">
           <span>우상단 설정에서 마이크를 활성화하세요</span>

--- a/tests/test_viewer_page.py
+++ b/tests/test_viewer_page.py
@@ -81,7 +81,8 @@ class TestViewerHtmlMarkup:
     def test_korean_state_labels_present(self, viewer_html):
         """한국어 상태 안내 카피 존재 (UX 기획 라벨)."""
         # 정확한 카피는 ux_spec.md 가 없어 issues.md 의 상태 표 라벨을 정본으로 본다.
-        assert "잠시 후 자막이 시작됩니다" in viewer_html
+        # #112: 대기 문구에서 "자막" 어절 제거 + 언어별 표시.
+        assert "잠시 후 시작됩니다" in viewer_html
         assert "세션이 종료되었습니다" in viewer_html
 
     def test_viewport_meta_for_mobile(self, viewer_html):


### PR DESCRIPTION
## 요약
디자인 2차(#111) 후속 다듬기 6건.

Closes #112

## 변경
1. **사이드바 이모지 제거** (app.py 헤더/버튼/상태 + 로그인/오류 문구).
2. **흰 버튼 글자 검정**: primary 버튼(시작/로그인) 글자가 흰 배경에 안 보이던 것 → 전역 CSS 주입으로 `#0b0b0c` 강제.
3. **룸 이름 별도 줄**: "룸 — 제목" 대시 조합 제거, 제목 아래 별도 줄에 표시.
4. **뷰어 대기 문구 언어별 + "자막" 제거**: "잠시 후 시작됩니다 / Starting shortly / 即将开始 / Sắp bắt đầu", 언어 변경 시 갱신.
5. **생성중 점 통일**: operator "· · ·" → 뷰어와 동일한 6px 촘촘한 점 3개.
6. **토스트 제거**: 컨퍼런스 중 상단 토스트 안 뜨게 (showToast 콘솔 전용).

## 검증
- 단위 **671 passed**, E2E **19 passed**
- Playwright 스크린샷: 룸이름 별도 줄, "Starting shortly", 촘촘한 생성중 점, 마지막 줄만 흰색

🤖 Generated with [Claude Code](https://claude.com/claude-code)