### PR TITLE
perf(translation): Bedrock 스트리밍 — 오퍼레이터 자막 부분 번역 실시간 표시

### DIFF
--- a/components/webrtc.html
+++ b/components/webrtc.html
@@ -1238,6 +1238,11 @@ try {
     if (currentTypingLine) {
       currentTypingLine.remove();
     }
+    // #114: 새 문장이 생성되기 시작하면 이전 확정 문장은 즉시 회색으로
+    // (스트리밍 중 현재 typing 줄만 흰색으로 부각).
+    captionContainer
+      .querySelectorAll('.caption-line.current')
+      .forEach((n) => n.classList.remove('current'));
     currentTypingLine = document.createElement('div');
     currentTypingLine.className = 'caption-line typing fade-in';
     // #112: 생성 중 표시 — 뷰어와 동일한 점 인디케이터(촘촘한 간격).
@@ -1721,6 +1726,15 @@ try {
     console.log('[Translation] 메시지 수신:', data);
 
     switch (data.type) {
+      case 'translation_partial':
+        // #114: Bedrock 스트리밍 부분 번역 — forming 버블을 누적 텍스트로
+        // 실시간 갱신(점 → 글자). 최종 확정은 transcription_result 가 한다.
+        if (data.text) {
+          if (!currentTypingLine) startTypingTranslation();
+          updateTypingTranslation(data.text);
+        }
+        break;
+
       case 'transcription_result':
         // 번역된 텍스트가 있으면 표시
         if (data.translated_text && data.translated_text !== data.original_text) {

--- a/tests/test_multilang_translation.py
+++ b/tests/test_multilang_translation.py
@@ -8,6 +8,8 @@ import json
 from io import BytesIO
 from unittest.mock import MagicMock
 
+import pytest
+
 from translation import (
     SOURCE_LANG_NAMES,
     _build_prompt_to_chinese,
@@ -245,3 +247,58 @@ class TestTranslateWithLlmMultilang:
         result = translate_with_llm(mock_client, "Xin chao", "vi", "en")
         assert result is not None
         assert "Hello" in result
+
+
+# === translate_with_llm_stream (#114) ===
+
+
+class TestTranslateWithLlmStream:
+    def _mk_delta(self, text):
+        payload = json.dumps(
+            {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": text},
+            }
+        ).encode()
+        return {"chunk": {"bytes": payload}}
+
+    def _mk_stop(self):
+        return {"chunk": {"bytes": json.dumps({"type": "message_stop"}).encode()}}
+
+    def _make_stream_bedrock(self, pieces):
+        mock = MagicMock()
+        events = [self._mk_delta(p) for p in pieces] + [self._mk_stop()]
+        mock.invoke_model_with_response_stream.return_value = {"body": events}
+        return mock
+
+    def test_yields_cumulative_then_final_done(self):
+        from translation import translate_with_llm_stream
+
+        mock = self._make_stream_bedrock(["아키", "텍처를", " 봅니다."])
+        chunks = list(
+            translate_with_llm_stream(mock, "Let me show the architecture", "en", "ko")
+        )
+        # 마지막은 done=True 이며 누적 최종 텍스트.
+        assert chunks[-1][1] is True
+        assert chunks[-1][0] == "아키텍처를 봅니다."
+        # 중간 조각은 done=False 이고 누적되어 커진다.
+        partials = [c for c in chunks if not c[1]]
+        assert partials[0] == ("아키", False)
+        assert partials[-1] == ("아키텍처를 봅니다.", False)
+
+    def test_uses_target_language_prompt(self):
+        from translation import translate_with_llm_stream
+
+        mock = self._make_stream_bedrock(["안녕"])
+        list(translate_with_llm_stream(mock, "Hello", "en", "ko"))
+        body = mock.invoke_model_with_response_stream.call_args.kwargs["body"]
+        prompt = json.loads(body)["messages"][0]["content"][0]["text"]
+        assert "한국어" in prompt
+
+    def test_raises_on_bedrock_error_for_fallback(self):
+        from translation import translate_with_llm_stream
+
+        mock = MagicMock()
+        mock.invoke_model_with_response_stream.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            list(translate_with_llm_stream(mock, "Hello", "en", "ko"))

--- a/translation.py
+++ b/translation.py
@@ -295,6 +295,39 @@ def _clean_llm_response(translated_text):
     return translated_text.strip()
 
 
+def _build_translation_prompt(text, source_lang, target_lang):
+    """target_lang 에 맞는 번역 프롬프트를 만든다 (translate_with_llm 과
+    translate_with_llm_stream 이 공유)."""
+    if target_lang == "ko":
+        return _build_prompt_to_korean(text, source_lang)
+    elif target_lang == "ja":
+        return _build_prompt_to_japanese(text, source_lang)
+    elif target_lang == "zh":
+        return _build_prompt_to_chinese(text, source_lang)
+    elif target_lang == "vi":
+        return _build_prompt_to_vietnamese(text, source_lang)
+    # en 등 나머지 (오퍼레이터 output_lang=en 경로). 뷰어 지원 언어
+    # (SUPPORTED_OUTPUT_LANGS)는 위 4개로 한정되므로 여기엔 안 온다.
+    return _build_prompt_to_english(text, source_lang)
+
+
+def _build_bedrock_body(prompt):
+    """Anthropic messages API 요청 바디 (JSON 문자열)."""
+    return json.dumps(
+        {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 200,
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": prompt}]}
+            ],
+            # Claude 4.5 세대는 temperature 와 top_p 동시 지정을 거부한다
+            # (ValidationException). 번역은 결정성이 중요하므로 temperature
+            # 만 남긴다 (#97).
+            "temperature": 0.5,
+        }
+    )
+
+
 def _invoke_bedrock_with_fallback(bedrock_client, body):
     """여러 모델을 시도하며 Bedrock 호출"""
     for model_id in BEDROCK_MODEL_IDS:
@@ -313,36 +346,29 @@ def _invoke_bedrock_with_fallback(bedrock_client, body):
     return None
 
 
+def _invoke_bedrock_stream_with_fallback(bedrock_client, body):
+    """여러 모델을 시도하며 Bedrock 스트리밍 호출 (#114)."""
+    for model_id in BEDROCK_MODEL_IDS:
+        try:
+            return bedrock_client.invoke_model_with_response_stream(
+                modelId=model_id,
+                body=body,
+                contentType="application/json",
+                accept="application/json",
+            )
+        except Exception as model_error:
+            print(f"    ⚠️ {model_id} 스트리밍 실패: {model_error}")
+            if model_id == BEDROCK_MODEL_IDS[-1]:
+                raise model_error
+    return None
+
+
 def translate_with_llm(bedrock_client, text, source_lang, target_lang):
     """Bedrock LLM을 사용한 고품질 컨텍스트 번역"""
     try:
-        if target_lang == "ko":
-            prompt = _build_prompt_to_korean(text, source_lang)
-        elif target_lang == "ja":
-            prompt = _build_prompt_to_japanese(text, source_lang)
-        elif target_lang == "zh":
-            prompt = _build_prompt_to_chinese(text, source_lang)
-        elif target_lang == "vi":
-            prompt = _build_prompt_to_vietnamese(text, source_lang)
-        else:
-            # en 등 나머지 (오퍼레이터 output_lang=en 경로). 뷰어 지원 언어
-            # (SUPPORTED_OUTPUT_LANGS)는 위 4개로 한정되므로 여기엔 안 온다.
-            prompt = _build_prompt_to_english(text, source_lang)
-
-        body = json.dumps(
-            {
-                "anthropic_version": "bedrock-2023-05-31",
-                "max_tokens": 200,
-                "messages": [
-                    {"role": "user", "content": [{"type": "text", "text": prompt}]}
-                ],
-                # Claude 4.5 세대는 temperature 와 top_p 동시 지정을 거부한다
-                # (ValidationException). 번역은 결정성이 중요하므로 temperature
-                # 만 남긴다 (#97).
-                "temperature": 0.5,
-            }
+        body = _build_bedrock_body(
+            _build_translation_prompt(text, source_lang, target_lang)
         )
-
         response = _invoke_bedrock_with_fallback(bedrock_client, body)
         response_body = json.loads(response["body"].read())
         translated_text = response_body["content"][0]["text"].strip()
@@ -352,3 +378,31 @@ def translate_with_llm(bedrock_client, text, source_lang, target_lang):
     except Exception as e:
         print(f"    ❌ LLM 번역 실패: {e}")
         return None
+
+
+def translate_with_llm_stream(bedrock_client, text, source_lang, target_lang):
+    """Bedrock 스트리밍 번역 (#114) — 토큰이 도착하는 대로 누적 텍스트를 yield.
+
+    각 yield 는 ``(cumulative_text, done)`` 튜플이다. 중간 조각은
+    ``done=False`` 로 원시 누적 텍스트를, 마지막에는 ``done=True`` 로
+    정리된(_clean_llm_response) 최종 텍스트를 한 번 더 yield 한다.
+
+    실패 시 예외를 그대로 올려 호출자가 비스트리밍(translate_with_llm /
+    Amazon Translate)으로 폴백할 수 있게 한다.
+    """
+    body = _build_bedrock_body(
+        _build_translation_prompt(text, source_lang, target_lang)
+    )
+    response = _invoke_bedrock_stream_with_fallback(bedrock_client, body)
+    acc = ""
+    for event in response["body"]:
+        chunk = event.get("chunk")
+        if not chunk:
+            continue
+        data = json.loads(chunk["bytes"])
+        if data.get("type") == "content_block_delta":
+            piece = (data.get("delta") or {}).get("text", "")
+            if piece:
+                acc += piece
+                yield acc, False
+    yield _clean_llm_response(acc), True

--- a/websocket_handler.py
+++ b/websocket_handler.py
@@ -22,7 +22,11 @@ from services import (
     get_aws_secret_access_key,
 )
 from sse_broadcast import BroadcastManager, broadcast_translation_for_room
-from translation import detect_language, translate_with_llm
+from translation import (
+    detect_language,
+    translate_with_llm,
+    translate_with_llm_stream,
+)
 
 # Per-connection rate limit: max messages per minute (sliding window)
 WS_RATE_LIMIT_PER_MINUTE = int(os.getenv("WS_RATE_LIMIT_PER_MINUTE", "30"))
@@ -385,6 +389,56 @@ def _record_usage(
         return audio_duration
 
 
+async def _stream_llm_translation(
+    websocket, bedrock_client, transcript, source_lang, target_lang
+):
+    """Bedrock 스트리밍 번역을 스레드에서 돌리며 부분 결과를 오퍼레이터 WS 로
+    ``translation_partial`` 로 흘려보낸다 (#114 — 발화 후 첫 글자까지의 체감
+    지연 단축).
+
+    반환: 최종 번역 텍스트(성공) 또는 None(실패 → 호출자가 폴백).
+    블로킹 boto3 스트림은 executor 스레드에서 돌리고, 청크는 asyncio.Queue
+    로 받아 이벤트 루프를 막지 않고 순차 전송한다.
+    """
+    loop = asyncio.get_running_loop()
+    q: asyncio.Queue = asyncio.Queue()
+
+    def _worker():
+        try:
+            for cumulative, done in translate_with_llm_stream(
+                bedrock_client, transcript, source_lang, target_lang
+            ):
+                loop.call_soon_threadsafe(q.put_nowait, ("chunk", cumulative, done))
+        except Exception as e:  # noqa: BLE001 — 폴백 트리거용
+            loop.call_soon_threadsafe(q.put_nowait, ("error", repr(e), True))
+        finally:
+            loop.call_soon_threadsafe(q.put_nowait, ("end", None, True))
+
+    fut = loop.run_in_executor(None, _worker)
+    final_text = None
+    errored = False
+    while True:
+        kind, payload, done = await q.get()
+        if kind == "end":
+            break
+        if kind == "error":
+            print(f"[Translate] 스트리밍 실패, 폴백: {payload}")
+            errored = True
+            continue
+        # kind == "chunk"
+        if done:
+            final_text = payload
+        else:
+            try:
+                await websocket.send(
+                    json.dumps({"type": "translation_partial", "text": payload})
+                )
+            except Exception as send_err:
+                print(f"[Translate] 부분 번역 전송 실패: {send_err!r}")
+    await fut
+    return None if errored else final_text
+
+
 async def _handle_transcript(
     websocket,
     data,
@@ -471,14 +525,25 @@ async def _handle_transcript(
         source_lang = input_lang
         target_lang = output_lang or "ko"
 
-    translated_text, used_llm = _translate_text(
-        transcript,
-        source_lang,
-        target_lang,
-        translate_client,
-        bedrock_client,
-        bedrock_available,
-    )
+    # #114: Bedrock LLM 번역을 스트리밍으로 받아 오퍼레이터 화면에 부분 결과를
+    # 즉시 흘려보낸다(체감 지연 단축). 스트리밍이 실패/빈 결과면 LLM 재시도
+    # 없이 Amazon Translate 로 폴백한다(bedrock_available=False 로 호출).
+    translated_text = None
+    used_llm = False
+    if bedrock_available:
+        translated_text = await _stream_llm_translation(
+            websocket, bedrock_client, transcript, source_lang, target_lang
+        )
+        used_llm = bool(translated_text)
+    if not translated_text:
+        translated_text, used_llm = _translate_text(
+            transcript,
+            source_lang,
+            target_lang,
+            translate_client,
+            bedrock_client,
+            bedrock_available=False,
+        )
 
     audio_duration = _record_usage(
         current_user,


### PR DESCRIPTION
## 요약
발화 후 번역 **전체**가 만들어질 때까지(~1초) 화면이 비어 있던 지연을 없앤다. Bedrock 스트리밍으로 **첫 글자가 ~0.3초**에 뜨고 타이핑되듯 채워진다.

Closes #114

## 변경
- `translation.py`: `translate_with_llm_stream` (invoke_model_with_response_stream) + 프롬프트/바디 빌더 추출. 기존 `translate_with_llm` 동작 불변.
- `websocket_handler.py`: `_stream_llm_translation` — boto3 스트림을 executor 스레드에서 돌리고 asyncio.Queue 로 청크를 받아 루프 블로킹 없이 `translation_partial` 전송. 실패 시 Amazon Translate 폴백. 최종 `transcription_result` 는 기존대로.
- `webrtc.html`: `translation_partial` → forming 버블 실시간 갱신, 새 문장 시작 시 이전 줄 회색 처리.

## 범위
이번엔 **오퍼레이터 화면(WS)** 스트리밍만 (가장 눈에 띄는 투사 화면). 뷰어 SSE 스트리밍은 후속.

## 검증
- 단위 **674 passed** (스트리밍 테스트 3개 추가), E2E **17 passed**
- Playwright: 부분 번역이 타이핑 버블에 실시간 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)